### PR TITLE
Fixing a bug when trying to parse keys from recursive GET.

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -128,7 +128,7 @@ class Consul(object):
                 else:
                     data = json.loads(response.body)
                     for item in data:
-                        if item.get('Value', None) is not None:
+                        if item.get('Value') is not None:
                             item['Value'] = base64.b64decode(item['Value'])
                     if not recurse:
                         data = data[0]


### PR DESCRIPTION
When executing a recursive list of keys, the parent folder is being included as a result. However, as it is a folder, the value is set is to None. This is breaking when trying to base64 decode the value. The bug is fixed by only parsing the values that are known to be strings.
