### PR TITLE
Fix typo to allow Health Checks to use the Notes field.

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -398,7 +398,7 @@ class Consul(object):
                     payload['ttl'] = ttl
 
                 if notes:
-                    payload['note'] = notes
+                    payload['notes'] = notes
 
                 return self.agent.http.put(
                     lambda x: x.code == 200,


### PR DESCRIPTION
Without this fix, Health Checks look like this (before):

```
{                                                                                                 
...                                                    
    "Status": "passing",                                                                          
    "Notes": "",
    "Output": "[0, 11, 9]",                                                                                             
...
},                                                                                                                      
```

and (after):

```
{                                                                                                 
...                                                    
    "Status": "passing",                                                                          
    "Notes": "Percentages, warning levels: 'CPU' over 85%; 'Memory' over 85%; 'Root Disk' over 85%, every 20s, TTL 60s",
    "Output": "[0, 11, 9]",                                                                                             
 ...
},                                                                                                                      
```
