### PR TITLE
Closes #13. Added flag to query wan members

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -287,15 +287,20 @@ class Consul(object):
             return self.agent.http.get(
                 lambda x: json.loads(x.body), '/v1/agent/checks')
 
-        def members(self):
+        def members(self, wan=False):
             """
             Returns all the members that this agent currently sees. This may
             vary by agent, use the nodes api of Catalog to retrieve a cluster
             wide consistent view of members
             """
-            # TODO: add wan flag
+            params = {}
+            if wan:
+                params['wan'] = 1
+
             return self.agent.http.get(
-                lambda x: json.loads(x.body), '/v1/agent/members')
+                lambda x: json.loads(x.body),
+                '/v1/agent/members',
+                params=params)
 
         class Service(object):
             def __init__(self, agent):

--- a/tests/test_std.py
+++ b/tests/test_std.py
@@ -188,6 +188,10 @@ class TestConsul(object):
             assert not x['Tags'] is None
         assert c.agent.self()['Member'] in members
 
+        wan_members = c.agent.members(wan=True)
+        for x in wan_members:
+            assert 'dc1' in x['Name']
+
     def test_agent_self(self, consul_port):
         c = consul.Consul(port=consul_port)
         assert set(c.agent.self().keys()) == set(['Member', 'Config'])


### PR DESCRIPTION
Again, not a massive amount to test here without a proper cluster. Name gets suffixed with the datacenter name, so test that is observed.