### PR TITLE
Added keys_only and separator options to kv.get

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ pip-log.txt
 
 # Ropemacs
 .ropeproject
+
+# IntelliJ project files
+*.iml
+.idea/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Features
 
 * Add dc support for kv calls; add ability to set the default dc for an entire
   client session (thanks @angad)
+* Add asyncio client (thanks @jettify)
 
 0.3.6
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Change log
 ==========
 
+0.3.8
+-----
+
+API changes (backwards incompatible)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Reorder named arguments to be more consistent. index is always the first
+  named argument, if available, and dc is now always the last named argument.
+
 0.3.7
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Change log
 ==========
 
+0.3.7
+-----
+
+Features
+~~~~~~~~
+
+* Add dc support for kv calls; add ability to set the default dc for an entire
+  client session (thanks @angad)
+
 0.3.6
 -----
 

--- a/consul/__init__.py
+++ b/consul/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.7'
+__version__ = '0.3.8'
 
 from consul.std import Consul
 

--- a/consul/__init__.py
+++ b/consul/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.6'
+__version__ = '0.3.7'
 
 from consul.std import Consul
 

--- a/consul/aio.py
+++ b/consul/aio.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import
+import asyncio
+import aiohttp
+
+from six.moves import urllib
+from . import base
+
+
+__all__ = ['Consul']
+
+
+class HTTPClient:
+    """Asyncio adapter for python consul using aiohttp library"""
+
+    def __init__(self, host='127.0.0.1', port=8500, scheme='http', loop=None):
+        self.host = host
+        self.port = port
+        self.scheme = scheme
+        self.base_uri = '%s://%s:%s' % (self.scheme, self.host, self.port)
+        self._loop = loop or asyncio.get_event_loop()
+        self._connector = aiohttp.TCPConnector(loop=self._loop)
+
+    def _uri(self, path, params=None):
+        uri = self.base_uri + path
+        if not params:
+            return uri
+        return '%s?%s' % (uri, urllib.parse.urlencode(params))
+
+    @asyncio.coroutine
+    def _request(self, callback, method, uri, data=None):
+        resp = yield from aiohttp.request(method, uri,
+                                          connector=self._connector,
+                                          data=data, loop=self._loop)
+        body = yield from resp.text(encoding='utf-8')
+        if resp.status == 599:
+            raise base.Timeout
+        r = base.Response(resp.status, resp.headers, body)
+        return callback(r)
+
+    def get(self, callback, path, params=None):
+        uri = self._uri(path, params)
+        return self._request(callback, 'GET', uri)
+
+    def put(self, callback, path, params=None, data=''):
+        uri = self._uri(path, params)
+        return self._request(callback, 'PUT', uri, data=data)
+
+    def delete(self, callback, path, params=None):
+        uri = self._uri(path, params)
+        return self._request(callback, 'DELETE', uri)
+
+
+class Consul(base.Consul):
+
+    def __init__(self, *args, loop=None, **kwargs):
+        self._loop = loop or asyncio.get_event_loop()
+        super().__init__(*args, **kwargs)
+
+    def connect(self, host, port, scheme):
+        return HTTPClient(host, port, scheme, loop=self._loop)

--- a/consul/aio.py
+++ b/consul/aio.py
@@ -3,7 +3,7 @@ import asyncio
 import aiohttp
 
 from six.moves import urllib
-from . import base
+from consul import base
 
 
 __all__ = ['Consul']

--- a/consul/base.py
+++ b/consul/base.py
@@ -70,6 +70,9 @@ class Consul(object):
         that support the consistency option. It's still possible to override
         this by passing explicitly for a given request. *consistency* can be
         either 'default', 'consistent' or 'stale'.
+
+        *dc* is the datacenter that this agent will communicate with.
+        By default the datacenter of the host is used.
         """
 
         # TODO: Event, Status

--- a/consul/base.py
+++ b/consul/base.py
@@ -507,7 +507,7 @@ class Consul(object):
         def __init__(self, agent):
             self.agent = agent
 
-        def register(self, node, address, dc=None, service=None, check=None):
+        def register(self, node, address, service=None, check=None, dc=None):
             """
             A low level mechanism for directly registering or updating entries
             in the catalog. It is usually recommended to use
@@ -517,9 +517,6 @@ class Consul(object):
             *node* is the name of the node to register.
 
             *address* is the ip of the node.
-
-            *dc* is the datacenter of the node and defaults to this agents
-            datacenter.
 
             *service* is an optional service to register. if supplied this is a
             dict::
@@ -555,6 +552,9 @@ class Consul(object):
                     "ServiceID": "redis1"
                 }
 
+            *dc* is the datacenter of the node and defaults to this agents
+            datacenter.
+
             This manipulates the health check entry, but does not setup a
             script or TTL to actually update the status. The full documentation
             is `here <https://consul.io/docs/agent/http.html#catalog>`_.
@@ -573,7 +573,7 @@ class Consul(object):
                 callback(is_200=True),
                 '/v1/catalog/register', data=json.dumps(data))
 
-        def deregister(self, node, dc=None, service_id=None, check_id=None):
+        def deregister(self, node, service_id=None, check_id=None, dc=None):
             """
             A low level mechanism for directly removing entries in the catalog.
             It is usually recommended to use the agent APIs, as they are
@@ -607,7 +607,7 @@ class Consul(object):
             return self.agent.http.get(
                 lambda x: json.loads(x.body), '/v1/catalog/datacenters')
 
-        def nodes(self, dc=None, index=None, consistency=None):
+        def nodes(self, index=None, consistency=None, dc=None):
             """
             Returns a tuple of (*index*, *nodes*) of all nodes known
             about in the *dc* datacenter. *dc* defaults to the current
@@ -646,7 +646,7 @@ class Consul(object):
                 callback(is_json=True, index=True),
                 '/v1/catalog/nodes', params=params)
 
-        def services(self, dc=None, index=None, consistency=None):
+        def services(self, index=None, consistency=None, dc=None):
             """
             Returns a tuple of (*index*, *services*) of all services known
             about in the *dc* datacenter. *dc* defaults to the current
@@ -686,13 +686,10 @@ class Consul(object):
                 callback(is_json=True, index=True),
                 '/v1/catalog/services', params=params)
 
-        def node(self, node, dc=None, index=None, consistency=None):
+        def node(self, node, index=None, consistency=None, dc=None):
             """
             Returns a tuple of (*index*, *services*) of all services provided
             by *node*.
-
-            *dc* is the datacenter of the node and defaults to this agents
-            datacenter.
 
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
@@ -700,6 +697,9 @@ class Consul(object):
             *consistency* can be either 'default', 'consistent' or 'stale'. if
             not specified *consistency* will the consistency level this client
             was configured with.
+
+            *dc* is the datacenter of the node and defaults to this agents
+            datacenter.
 
             The response looks like this::
 
@@ -742,20 +742,20 @@ class Consul(object):
         def service(
                 self,
                 service,
-                dc=None,
-                tag=None,
                 index=None,
-                consistency=None):
+                tag=None,
+                consistency=None,
+                dc=None):
             """
             Returns a tuple of (*index*, *nodes*) of the nodes providing
             *service* in the *dc* datacenter. *dc* defaults to the current
             datacenter of this agent.
 
-            If *tag* is provided, the list of nodes returned will be filtered
-            by that tag.
-
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
+
+            If *tag* is provided, the list of nodes returned will be filtered
+            by that tag.
 
             *consistency* can be either 'default', 'consistent' or 'stale'. if
             not specified *consistency* will the consistency level this client
@@ -905,7 +905,7 @@ class Consul(object):
                 callback(is_200=True),
                 '/v1/session/destroy/%s' % session_id, params=params)
 
-        def list(self, dc=None, index=None, consistency=None):
+        def list(self, index=None, consistency=None, dc=None):
             """
             Returns a tuple of (*index*, *sessions*) of all active sessions in
             the *dc* datacenter. *dc* defaults to the current datacenter of
@@ -946,7 +946,7 @@ class Consul(object):
                 callback(is_json=True, index=True),
                 '/v1/session/list', params=params)
 
-        def node(self, node, dc=None, index=None, consistency=None):
+        def node(self, node, index=None, consistency=None, dc=None):
             """
             Returns a tuple of (*index*, *sessions*) as per *session.list*, but
             filters the sessions returned to only those active for *node*.
@@ -971,7 +971,7 @@ class Consul(object):
                 callback(is_json=True, index=True),
                 '/v1/session/node/%s' % node, params=params)
 
-        def info(self, session_id, dc=None, index=None, consistency=None):
+        def info(self, session_id, index=None, consistency=None, dc=None):
             """
             Returns a tuple of (*index*, *session*) for the session
             *session_id* in the *dc* datacenter. *dc* defaults to the current

--- a/consul/base.py
+++ b/consul/base.py
@@ -101,7 +101,9 @@ class Consul(object):
                 index=None,
                 recurse=False,
                 token=None,
-                consistency=None):
+                consistency=None,
+                keys_only=False,
+                separator=None):
             """
             Returns a tuple of (*index*, *value[s]*)
 
@@ -139,6 +141,10 @@ class Consul(object):
             token = token or self.agent.token
             if token:
                 params['token'] = token
+            if keys_only:
+                params['keys'] = True
+            if separator:
+                params['separator'] = separator
             consistency = consistency or self.agent.consistency
             if consistency in ('consistent', 'stale'):
                 params[consistency] = '1'
@@ -148,11 +154,12 @@ class Consul(object):
                     data = None
                 else:
                     data = json.loads(response.body)
-                    for item in data:
-                        if item.get('Value') is not None:
-                            item['Value'] = base64.b64decode(item['Value'])
-                    if not recurse:
-                        data = data[0]
+                    if not keys_only:
+                        for item in data:
+                            if item.get('Value') is not None:
+                                item['Value'] = base64.b64decode(item['Value'])
+                        if not recurse:
+                            data = data[0]
                 return response.headers['X-Consul-Index'], data
 
             return self.agent.http.get(

--- a/consul/base.py
+++ b/consul/base.py
@@ -116,6 +116,7 @@ class Consul(object):
             *token* is an optional `ACL token`_ to apply to this request.
 
             *dc* is the optional datacenter that you wish to communicate with.
+            If None is provided, defaults to the agent's datacenter.
 
             The *value* returned is for the specified key, or if *recurse* is
             True a list of *values* for all keys with the given prefix is
@@ -211,6 +212,7 @@ class Consul(object):
             *ACLPermissionDenied* exception will be raised.
 
             *dc* is the optional datacenter that you wish to communicate with.
+            If None is provided, defaults to the agent's datacenter.
 
             The return value is simply either True or False. If False is
             returned, then the update has not taken place.
@@ -249,6 +251,7 @@ class Consul(object):
             *ACLPermissionDenied* exception will be raised.
 
             *dc* is the optional datacenter that you wish to communicate with.
+            If None is provided, defaults to the agent's datacenter.
             """
             assert not key.startswith('/')
 
@@ -556,6 +559,7 @@ class Consul(object):
             Returns *True* on success.
             """
             data = {'node': node, 'address': address}
+            dc = dc or self.agent.dc
             if dc:
                 data['datacenter'] = dc
             if service:
@@ -582,6 +586,7 @@ class Consul(object):
             """
             assert not (service_id and check_id)
             data = {'node': node}
+            dc = dc or self.agent.dc
             if dc:
                 data['datacenter'] = dc
             if service_id:
@@ -626,6 +631,7 @@ class Consul(object):
                 ])
             """
             params = {}
+            dc = dc or self.agent.dc
             if dc:
                 params['dc'] = dc
             if index:
@@ -665,6 +671,7 @@ class Consul(object):
             known tags for a given service.
             """
             params = {}
+            dc = dc or self.agent.dc
             if dc:
                 params['dc'] = dc
             if index:
@@ -717,6 +724,7 @@ class Consul(object):
                 })
             """
             params = {}
+            dc = dc or self.agent.dc
             if dc:
                 params['dc'] = dc
             if index:
@@ -764,6 +772,7 @@ class Consul(object):
                 ])
             """
             params = {}
+            dc = dc or self.agent.dc
             if dc:
                 params['dc'] = dc
             if tag:
@@ -859,6 +868,7 @@ class Consul(object):
             Returns the string *session_id* for the session.
             """
             params = {}
+            dc = dc or self.agent.dc
             if dc:
                 params['dc'] = dc
             data = {}
@@ -885,6 +895,7 @@ class Consul(object):
             Returns *True* on success.
             """
             params = {}
+            dc = dc or self.agent.dc
             if dc:
                 params['dc'] = dc
             return self.agent.http.put(
@@ -920,6 +931,7 @@ class Consul(object):
                ])
             """
             params = {}
+            dc = dc or self.agent.dc
             if dc:
                 params['dc'] = dc
             if index:
@@ -944,6 +956,7 @@ class Consul(object):
             was configured with.
             """
             params = {}
+            dc = dc or self.agent.dc
             if dc:
                 params['dc'] = dc
             if index:
@@ -969,6 +982,7 @@ class Consul(object):
             was configured with.
             """
             params = {}
+            dc = dc or self.agent.dc
             if dc:
                 params['dc'] = dc
             if index:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,10 +71,48 @@ need to *yield* the result of each API call. This client is available in
                 index, data = yield c.kv.get('foo', index=index)
                 self.foo = data['Value']
 
+asyncio
+~~~~~~~
+
+There is a `asyncio`_ (using aiohttp_) client which works with `Python3.4` and
+makes use of `asyncio.coroutine`_. The API for this client is identical to
+the standard python-consul client except that you need to ``yield from`` the
+result of each API call. This client is available in *consul.aio*.
+
+.. code:: python
+
+    import asyncio
+    import consul.aio
+
+
+    loop = asyncio.get_event_loop()
+
+    @asyncio.coroutine
+    def go():
+
+        # always better to pass ``loop`` explicitly, but this
+        # is not mandatory, you can relay on global event loop
+        c = consul.aio.Consul(port=consul_port, loop=loop)
+
+        # set value, same as default api but with ``yield from``
+        response = yield from c.kv.put(b'foo', b'bar')
+        assert response is True
+
+        # get value
+        index, data = yield from c.kv.get(b'foo')
+        assert data['Value'] == b'bar'
+
+        # delete value
+        response = yield from c.kv.delete(b'foo2')
+        assert response is True
+
+    loop.run_until_complete(go())
+
+
 Wanted
 ~~~~~~
 
-Adaptors for `asyncio`_, `Twisted`_ and a `thread pool`_ based adaptor.
+Adaptors for `Twisted`_ and a `thread pool`_ based adaptor.
 
 Tools
 -----
@@ -189,7 +227,8 @@ consul.acl
 .. _gevent: http://www.gevent.org
 .. _Tornado: http://www.tornadoweb.org
 .. _gen.coroutine: http://tornado.readthedocs.org/en/latest/gen.html
-
+.. _asyncio.coroutine: https://docs.python.org/3/library/asyncio-task.html#coroutines
+.. _aiohttp: https://github.com/KeepSafe/aiohttp
 .. _asyncio: https://docs.python.org/3/library/asyncio.html
 .. _Twisted: https://twistedmatrix.com/trac/
 .. _thread pool: https://docs.python.org/2/library/threading.html

--- a/setup.py
+++ b/setup.py
@@ -35,13 +35,16 @@ setup(
     version=metadata['version'],
     author='Andy Gayton',
     author_email='andy@thecablelounge.com',
-    install_requires=requirements,
-    packages=find_packages(),
     url='https://github.com/cablehead/python-consul',
     license='MIT',
     description=description,
     long_description=open('README.rst').read() + '\n\n' +
         open('CHANGELOG.rst').read(),
+    packages=find_packages(),
+    install_requires=requirements,
+    extras_require={
+        'asyncio': ['aiohttp'],
+    },
     tests_require=['pytest'],
     cmdclass={'test': PyTest},
     classifiers=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import collections
 import subprocess
 import platform
+import sys
 import tempfile
 import socket
 import shlex
@@ -12,6 +13,12 @@ import os
 import requests
 import pytest
 import py
+
+
+collect_ignore = []
+if sys.version_info[0] < 3:
+    p = os.path.join(os.path.dirname(__file__), 'test_aio.py')
+    collect_ignore.append(p)
 
 
 def get_free_ports(num, host=None):
@@ -56,7 +63,6 @@ def start_consul_instance(acl_master_token=None):
         postfix = 'osx'
     else:
         postfix = 'linux64'
-
     bin = os.path.join(os.path.dirname(__file__), 'consul.'+postfix)
     command = """
         {bin} agent -server -bootstrap -config-dir=. -data-dir=./data

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,14 +1,10 @@
 import pytest
 import six
 import struct
-import sys
-
-pytest.mark.skipif(sys.version_info < (3, 3), reason="requires python3.4")
 
 import asyncio
 import consul
 import consul.aio
-
 
 
 @pytest.fixture

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -2,7 +2,7 @@ import asyncio
 import pytest
 import six
 import struct
-import time
+import sys
 
 import consul
 import consul.aio
@@ -15,6 +15,7 @@ def loop():
     return loop
 
 
+@pytest.mark.skipif(sys.version_info < (3, 3), reason="requires python3.3")
 class TestAsyncioConsul(object):
 
     def test_kv(self, loop, consul_port):

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,0 +1,342 @@
+import asyncio
+import pytest
+import six
+import struct
+import time
+
+import consul
+import consul.aio
+
+
+@pytest.fixture
+def loop():
+    asyncio.set_event_loop(None)
+    loop = asyncio.new_event_loop()
+    return loop
+
+
+class TestConsul(object):
+
+    def test_kv(self, loop, consul_port):
+
+        @asyncio.coroutine
+        def main():
+            c = consul.aio.Consul(port=consul_port, loop=loop)
+            print(c)
+            index, data = yield from c.kv.get('foo')
+
+            print(index, data)
+            assert data is None
+            response = yield from c.kv.put('foo', 'bar')
+            assert response is True
+            index, data = yield from c.kv.get('foo')
+            assert data['Value'] == six.b('bar')
+
+        loop.run_until_complete(main())
+
+    def test_consul_ctor(self, loop, consul_port):
+        # same as previous but with global event loop
+        @asyncio.coroutine
+        def main():
+            c = consul.aio.Consul(port=consul_port)
+            assert c._loop is loop
+            yield from c.kv.put('foo', struct.pack('i', 1000))
+            index, data = yield from c.kv.get('foo')
+            assert struct.unpack('i', data['Value']) == (1000,)
+
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(main())
+
+    def test_kv_binary(self, loop, consul_port):
+        @asyncio.coroutine
+        def main():
+            c = consul.aio.Consul(port=consul_port, loop=loop)
+            yield from c.kv.put('foo', struct.pack('i', 1000))
+            index, data = yield from c.kv.get('foo')
+            assert struct.unpack('i', data['Value']) == (1000,)
+
+        loop.run_until_complete(main())
+
+    def test_kv_missing(self, loop, consul_port):
+        c = consul.aio.Consul(port=consul_port, loop=loop)
+
+        @asyncio.coroutine
+        def main():
+            fut = asyncio.async(put(), loop=loop)
+            yield from c.kv.put('index', 'bump')
+            index, data = yield from c.kv.get('foo')
+            assert data is None
+            index, data = yield from c.kv.get('foo', index=index)
+            assert data['Value'] == six.b('bar')
+            yield from fut
+
+        @asyncio.coroutine
+        def put():
+            yield from asyncio.sleep(3.0/100, loop=loop)
+            yield from c.kv.put('foo', 'bar')
+
+        loop.run_until_complete(main())
+
+    def test_kv_put_flags(self, loop, consul_port):
+        @asyncio.coroutine
+        def main():
+            c = consul.aio.Consul(port=consul_port, loop=loop)
+            yield from c.kv.put('foo', 'bar')
+            index, data = yield from c.kv.get('foo')
+            assert data['Flags'] == 0
+
+            response = yield from c.kv.put('foo', 'bar', flags=50)
+            assert response is True
+            index, data = yield from c.kv.get('foo')
+            assert data['Flags'] == 50
+
+        loop.run_until_complete(main())
+
+    def test_kv_delete(self, loop, consul_port):
+        @asyncio.coroutine
+        def main():
+            c = consul.aio.Consul(port=consul_port, loop=loop)
+            yield from c.kv.put('foo1', '1')
+            yield from c.kv.put('foo2', '2')
+            yield from c.kv.put('foo3', '3')
+            index, data = yield from c.kv.get('foo', recurse=True)
+            assert [x['Key'] for x in data] == ['foo1', 'foo2', 'foo3']
+
+            response = yield from c.kv.delete('foo2')
+            assert response is True
+            index, data = yield from c.kv.get('foo', recurse=True)
+            assert [x['Key'] for x in data] == ['foo1', 'foo3']
+            response = yield from c.kv.delete('foo', recurse=True)
+            assert response is True
+            index, data = yield from c.kv.get('foo', recurse=True)
+            assert data is None
+
+        loop.run_until_complete(main())
+
+    def test_kv_subscribe(self, loop, consul_port):
+        c = consul.aio.Consul(port=consul_port, loop=loop)
+
+        @asyncio.coroutine
+        def get():
+            fut = asyncio.async(put(), loop=loop)
+            index, data = yield from c.kv.get('foo')
+            assert data is None
+            index, data = yield from c.kv.get('foo', index=index)
+            assert data['Value'] == six.b('bar')
+            yield from fut
+
+        @asyncio.coroutine
+        def put():
+            yield from asyncio.sleep(1.0/100, loop=loop)
+            response = yield from c.kv.put('foo', 'bar')
+            assert response is True
+
+        loop.run_until_complete(get())
+
+    def test_agent_services(self, loop, consul_port):
+        @asyncio.coroutine
+        def main():
+            c = consul.aio.Consul(port=consul_port, loop=loop)
+            services = yield from c.agent.services()
+            del services['consul']
+            assert services == {}
+            response = yield from c.agent.service.register('foo')
+            assert response is True
+            services = yield from c.agent.services()
+            del services['consul']
+            assert services == {
+                'foo': {
+                    'Port': 0, 'ID': 'foo', 'Service': 'foo', 'Tags': None}}
+            response = yield from c.agent.service.deregister('foo')
+            assert response is True
+            services = yield from c.agent.services()
+            del services['consul']
+            assert services == {}
+        loop.run_until_complete(main())
+
+    def test_catalog(self, loop, consul_port):
+        c = consul.aio.Consul(port=consul_port, loop=loop)
+
+        @asyncio.coroutine
+        def nodes():
+            fut = asyncio.async(register(), loop=loop)
+            index, nodes = yield from c.catalog.nodes()
+            assert len(nodes) == 1
+            current = nodes[0]
+
+            index, nodes = yield from c.catalog.nodes(index=index)
+            nodes.remove(current)
+            assert [x['Node'] for x in nodes] == ['n1']
+
+            index, nodes = yield from c.catalog.nodes(index=index)
+            nodes.remove(current)
+            assert [x['Node'] for x in nodes] == []
+            yield from fut
+
+        @asyncio.coroutine
+        def register():
+            yield from asyncio.sleep(1.0/100, loop=loop)
+            response = yield from c.catalog.register('n1', '10.1.10.11')
+            assert response is True
+            yield from asyncio.sleep(50/1000.0, loop=loop)
+            response = yield from c.catalog.deregister('n1')
+            assert response is True
+
+        loop.run_until_complete(nodes())
+
+    def test_health_service(self, loop, consul_port):
+        @asyncio.coroutine
+        def main():
+            c = consul.aio.Consul(port=consul_port, loop=loop)
+
+            # check there are no nodes for the service 'foo'
+            index, nodes = yield from c.health.service('foo')
+            assert nodes == []
+
+            # register two nodes, one with a long ttl, the other shorter
+            yield from c.agent.service.register(
+                'foo', service_id='foo:1', ttl='10s')
+            yield from c.agent.service.register(
+                'foo', service_id='foo:2', ttl='100ms')
+
+            yield from asyncio.sleep(30/1000.0, loop=loop)
+
+            # check the nodes show for the /health/service endpoint
+            index, nodes = yield from c.health.service('foo')
+            assert [node['Service']['ID'] for node in nodes] == \
+                ['foo:1', 'foo:2']
+
+            # but that they aren't passing their health check
+            index, nodes = yield from c.health.service('foo', passing=True)
+            assert nodes == []
+
+            # ping the two node's health check
+            yield from c.health.check.ttl_pass('service:foo:1')
+            yield from c.health.check.ttl_pass('service:foo:2')
+
+            yield from asyncio.sleep(50/1000.0, loop=loop)
+
+            # both nodes are now available
+            index, nodes = yield from c.health.service('foo', passing=True)
+            assert [node['Service']['ID'] for node in nodes] == \
+                ['foo:1', 'foo:2']
+
+            # wait until the short ttl node fails
+            yield from asyncio.sleep(120/1000.0, loop=loop)
+
+            # only one node available
+            index, nodes = yield from c.health.service('foo', passing=True)
+            assert [node['Service']['ID'] for node in nodes] == ['foo:1']
+
+            # ping the failed node's health check
+            yield from c.health.check.ttl_pass('service:foo:2')
+
+            yield from asyncio.sleep(30/1000.0, loop=loop)
+
+            # check both nodes are available
+            index, nodes = yield from c.health.service('foo', passing=True)
+            assert [node['Service']['ID'] for node in nodes] == \
+                ['foo:1', 'foo:2']
+
+            # deregister the nodes
+            yield from c.agent.service.deregister('foo:1')
+            yield from c.agent.service.deregister('foo:2')
+
+            yield from asyncio.sleep(30/1000.0, loop=loop)
+
+            index, nodes = yield from c.health.service('foo')
+            assert nodes == []
+
+        loop.run_until_complete(main())
+
+    def test_health_service_subscribe(self, loop, consul_port):
+        c = consul.aio.Consul(port=consul_port, loop=loop)
+
+        class Config(object):
+            pass
+
+        config = Config()
+
+        @asyncio.coroutine
+        def monitor():
+            yield from c.agent.service.register(
+                'foo', service_id='foo:1', ttl='40ms')
+            index = None
+            while True:
+                index, nodes = yield from c.health.service(
+                    'foo', index=index, passing=True)
+                config.nodes = [node['Service']['ID'] for node in nodes]
+
+        @asyncio.coroutine
+        def keepalive():
+            # give the monitor a chance to register the service
+            yield from asyncio.sleep(50/1000.0, loop=loop)
+            assert config.nodes == []
+
+            # ping the service's health check
+            yield from c.health.check.ttl_pass('service:foo:1')
+            yield from asyncio.sleep(30/1000.0, loop=loop)
+            assert config.nodes == ['foo:1']
+
+            # the service should fail
+            yield from asyncio.sleep(60/1000.0, loop=loop)
+            assert config.nodes == []
+
+            yield from c.agent.service.deregister('foo:1')
+
+        waiter = asyncio.gather(keepalive(), monitor(), loop=loop)
+        loop.run_until_complete(waiter)
+
+    def test_session(self, loop, consul_port):
+        c = consul.aio.Consul(port=consul_port, loop=loop)
+
+        @asyncio.coroutine
+        def monitor():
+            fut = asyncio.async(register(), loop=loop)
+            index, services = yield from c.session.list()
+            assert services == []
+            yield from asyncio.sleep(20/100.0, loop=loop)
+
+            index, services = yield from c.session.list(index=index)
+            assert len(services)
+
+            index, services = yield from c.session.list(index=index)
+            assert services == []
+            yield from fut
+
+        @asyncio.coroutine
+        def register():
+            yield from asyncio.sleep(1.0/100, loop=loop)
+            session_id = yield from c.session.create()
+            yield from asyncio.sleep(50/100.0, loop=loop)
+            response = yield from c.session.destroy(session_id)
+            assert response is True
+
+        loop.run_until_complete(monitor())
+
+    def test_acl(self, loop, acl_consul):
+        @asyncio.coroutine
+        def main():
+            c = consul.aio.Consul(
+                port=acl_consul.port, token=acl_consul.token, loop=loop)
+
+            rules = """
+                key "" {
+                    policy = "read"
+                }
+                key "private/" {
+                    policy = "deny"
+                }
+            """
+            token = yield from c.acl.create(rules=rules)
+
+            try:
+                yield from c.acl.list(token=token)
+            except consul.ACLPermissionDenied:
+                raised = True
+            assert raised
+
+            destroyed = yield from c.acl.destroy(token)
+            assert destroyed is True
+
+        loop.run_until_complete(main())

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,11 +1,14 @@
-import asyncio
 import pytest
 import six
 import struct
 import sys
 
+pytest.mark.skipif(sys.version_info < (3, 3), reason="requires python3.4")
+
+import asyncio
 import consul
 import consul.aio
+
 
 
 @pytest.fixture
@@ -15,7 +18,6 @@ def loop():
     return loop
 
 
-@pytest.mark.skipif(sys.version_info < (3, 3), reason="requires python3.3")
 class TestAsyncioConsul(object):
 
     def test_kv(self, loop, consul_port):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = flake8, py27, pypy, py34
 
 [flake8]
 ignore = F811,E226
-exclude = .tox/*,xx/*,__*,docs/*
+exclude = .tox/*,xx/*,__*,docs/*, *aio.py
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,10 @@ deps =
     pytest
     tornado
     aiohttp
+    flake8
 commands =
     py.test consul tests
+    flake8 --exclude=".tox/*,xx/*,__*,docs/*"
 
 [testenv:flake8]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = flake8, py27, pypy, py34
 
 [flake8]
 ignore = F811,E226
-exclude = .tox/*,xx/*,__*,docs/*, *aio.py
+exclude = .tox/*,xx/*,__*,docs/*,*aio.py
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,14 @@ deps =
 commands =
     py.test consul tests
 
+[testenv:py34]
+deps =
+    pytest
+    tornado
+    aiohttp
+commands =
+    py.test consul tests
+
 [testenv:flake8]
 deps = flake8
 commands = flake8


### PR DESCRIPTION
Used keys_only rather than keys for the parameter because I thought it was clearer, but I can understand if you want to change that to just keys to match the 0.4.1 interface.

Also, this is my first pull request ever so let me know if I should be doing something different.