### PR TITLE
Closes #24. Adding support for the /health/state/* endpoint

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -834,6 +834,7 @@ class Consul(object):
             *nodes* are the nodes providing the given service.
 
             """
+            assert name in ['any', 'unknown', 'passing', 'warning', 'critical']
             params = {}
             if index:
                 params['index'] = index

--- a/consul/base.py
+++ b/consul/base.py
@@ -825,8 +825,8 @@ class Consul(object):
             *name* is a supported state. From the Consul docs:
 
                 The supported states are any, unknown, passing, warning, or
-                critical. The any state is a wildcard that can be used to return
-                all checks.
+                critical. The any state is a wildcard that can be used to
+                return all checks.
 
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
@@ -837,6 +837,7 @@ class Consul(object):
             params = {}
             if index:
                 params['index'] = index
+
             def callback(response):
                 data = json.loads(response.body)
                 return response.headers['X-Consul-Index'], data
@@ -844,7 +845,6 @@ class Consul(object):
             return self.agent.http.get(
                 callback,
                 '/v1/health/state/%s' % name, params=params)
-
 
         class Check(object):
             def __init__(self, agent):

--- a/consul/base.py
+++ b/consul/base.py
@@ -817,6 +817,35 @@ class Consul(object):
                 callback,
                 '/v1/health/service/%s' % service, params=params)
 
+        def state(self, name, index=None):
+            """
+
+            Returns a tuple of (*index*, *nodes*)
+
+            *name* is a supported state. From the Consul docs:
+
+                The supported states are any, unknown, passing, warning, or
+                critical. The any state is a wildcard that can be used to return
+                all checks.
+
+            *index* is the current Consul index, suitable for making subsequent
+            calls to wait for changes since this query was last run.
+
+            *nodes* are the nodes providing the given service.
+
+            """
+            params = {}
+            if index:
+                params['index'] = index
+            def callback(response):
+                data = json.loads(response.body)
+                return response.headers['X-Consul-Index'], data
+
+            return self.agent.http.get(
+                callback,
+                '/v1/health/state/%s' % name, params=params)
+
+
         class Check(object):
             def __init__(self, agent):
                 self.agent = agent


### PR DESCRIPTION
I think this does the trick. I copied your tests for the service endpoint and fixed them up a bit. It's not exhaustive (I only check `any` and `passing`, for example), but I hope  it's a good enough first step.