### PR TITLE
Raise ConsulException on kv GET 500 response code.

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -169,7 +169,9 @@ class Consul(object):
                 params[consistency] = '1'
 
             def callback(response):
-                if response.code == 404:
+                if response.code == 500:
+                    raise ConsulException(response.body)
+                elif response.code == 404:
                     data = None
                 else:
                     data = json.loads(response.body)


### PR DESCRIPTION
Any kv.get 500 response raises ValueError attempting to json decode the non-json response.

Raise ConsulException on response code 500.