### PR TITLE
Don't accept: Twisted compat initial cut

### DIFF
--- a/consul/twisted.py
+++ b/consul/twisted.py
@@ -1,0 +1,82 @@
+"""A twisted integration for consul."""
+from __future__ import absolute_import
+from six.moves import urllib
+from consul import base
+from twisted.internet.error import ConnectError
+from twisted.python import log
+
+import treq
+
+
+__all__ = ['Consul']
+
+
+class HTTPClient(object):
+
+    """A HTTPClient based off treq for twisted."""
+
+    def __init__(self, host="127.0.0.1", port=8500, scheme="http"):
+        self.host = host
+        self.port = port
+        self.scheme = scheme
+        self.base_uri = '%s://%s:%s' % (self.scheme, self.host, self.port)
+        self.client = treq
+
+    def uri(self, path, params=None):
+        uri = self.base_uri + path
+        if not params:
+            return uri
+        return '%s?%s' % (uri, urllib.parse.urlencode(params))
+
+    def wrap_response(self, response, content):
+
+        class HeaderWrapper(object):
+            headers = response.headers
+
+            def __getitem__(self, key):
+                return self.headers.getRawHeaders(key)[0]
+        return base.Response(
+            response.code, HeaderWrapper(), content)
+
+    def _request(self, callback, method, **kwargs):
+        d = method(**kwargs)
+        d.addCallback(self._handle_response)
+        d.addErrback(self.error)
+        d.addCallback(callback)
+        return d
+
+    def _handle_response(self, response):
+        d = response.text(encoding="utf8")
+        d.addCallback(
+            lambda _cont, _resp: self.wrap_response(_resp, _cont),
+            response
+        )
+        return d
+
+    def error(self, error):
+        print error
+        r = error.trap(ConnectError)
+        if r is ConnectError:
+            log.err("Is the Consul server running and accessible?")
+            return error
+
+    def get(self, callback, path, params=None):
+        uri = self.uri(path, params)
+        return self._request(callback, self.client.get, url=uri)
+
+    def put(self, callback, path, params=None, data=''):
+        uri = self.uri(path, params)
+        return self._request(callback, self.client.put, url=uri, data=data)
+
+    def delete(self, callback, path, params=None):
+        uri = self.uri(path, params)
+        return self._request(callback, self.client.delete, url=uri)
+
+
+class Consul(base.Consul):
+
+    """Subclass of consul to use twisted http client."""
+
+    def connect(self, host, port, scheme):
+        """Return a treq based http client."""
+        return HTTPClient(host, port, scheme)

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     extras_require={
         'tornado': ['tornado'],
         'asyncio': ['aiohttp'],
+        'twisted': ['twisted', 'treq']
     },
     tests_require=['pytest'],
     cmdclass={'test': PyTest},

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -5,7 +5,7 @@ Run these by  simply running:
     trial tests/test_twisted.py
 """
 import struct
-import six
+# import six
 
 from consul.twisted import Consul
 from twisted.internet import defer
@@ -54,3 +54,10 @@ class TwistedConsul(unittest.TestCase):
         # Line below seems to block.
         # index, data = yield self.c.kv.get('foo', index=index)
         # self.assertEqual(data['Value'], six.b('bar'))
+
+    @defer.inlineCallbacks
+    def test_agent_services(self):
+        """Test getting services from the agent."""
+        services = yield self.c.agent.services()
+        del services['consul']
+        self.assertEqual(services, {})

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -1,0 +1,56 @@
+"""
+Tests for the twisted integration.
+
+Run these by  simply running:
+    trial tests/test_twisted.py
+"""
+import struct
+import six
+
+from consul.twisted import Consul
+from twisted.internet import defer
+from twisted.trial import unittest
+from treq._utils import _global_pool as pool
+
+
+class TwistedConsul(unittest.TestCase):
+
+    """Tests for the Twisted HTTPClient based Consul."""
+
+    def setUp(self):
+        """Create the consul instance."""
+        self.c = Consul()
+
+    def tearDown(self):
+        """https://github.com/dreid/treq/issues/86."""
+        pool[0].closeCachedConnections()
+
+    @defer.inlineCallbacks
+    def test_kv(self):
+        """Test simple key value data."""
+        yield self.c.kv.delete('foo')
+        index, data = yield self.c.kv.get('foo')
+        self.assertEqual(data, None)
+        response = yield self.c.kv.put('foo', 'bar')
+        self.assertTrue(response)
+        index, data = yield self.c.kv.get('foo')
+        self.assertEqual(data['Value'], "bar")
+
+    @defer.inlineCallbacks
+    def test_kv_binary(self):
+        """Test binary key value data."""
+        yield self.c.kv.delete('foo')
+        yield self.c.kv.put('foo', struct.pack('i', 1000))
+        index, data = yield self.c.kv.get('foo')
+        self.assertEqual(struct.unpack('i', data['Value']), (1000,))
+
+    @defer.inlineCallbacks
+    def test_kv_missing(self):
+        """Test when a value is missing."""
+        yield self.c.kv.delete('foo')
+        yield self.c.kv.put('index', 'bump')
+        index, data = yield self.c.kv.get('foo')
+        self.assertEqual(data, None)
+        # Line below seems to block.
+        # index, data = yield self.c.kv.get('foo', index=index)
+        # self.assertEqual(data['Value'], six.b('bar'))


### PR DESCRIPTION
Initial version of twisted client, as per: https://github.com/cablehead/python-consul/issues/7
    
* Currently only some of the unit tests are implemented.
* Thus not all functionality is tested.
* Test running and quirks are documented in the test file.
* Tests aren't added to the tox config yet.
* Error handling is rough for the http client.
    
I'm mostly checking in to make sure this is an approach you're happy with.
