### PR TITLE
Clarify docs to give an example value for Consul.kv.get's wait parameter

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -227,9 +227,11 @@ class Consul(object):
             Returns a tuple of (*index*, *value[s]*)
 
             *index* is the current Consul index, suitable for making subsequent
-            calls to wait for changes since this query was last run. if *index*
-            is specified, *wait* may be set too, to indicated the maximum
-            duration to wait for. the default is 10 minutes.
+            calls to wait for changes since this query was last run.
+
+            *wait* the maximum duration to wait (e.g. '10ms') to retrieve
+            a given index. this parameter is only applied if *index* is also
+            specified. the wait time by default is 10 minutes.
 
             *token* is an optional `ACL token`_ to apply to this request.
 


### PR DESCRIPTION
I tried supplying a numerical value for the wait parameter, but that resulted in an exception. I then found that one of your tests sets the wait parameter to '10ms' so I thought it would be useful to give that example up front in the docs.