### PR TITLE
require six>=1.4 (python_consul won't work with earlier versions)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-six
+six>=1.4


### PR DESCRIPTION
```
$ pip install 'six==1.3'

.. cut ...

$ python -c 'import consul'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "consul/__init__.py", line 3, in <module>
    from consul.std import Consul
  File "consul/std.py", line 1, in <module>
    from six.moves import urllib
ImportError: cannot import name urllib
```

Works with 1.4 up.