### PR TITLE
add close method to aio.Counsul to finalize http connections

### DIFF
--- a/consul/aio.py
+++ b/consul/aio.py
@@ -49,6 +49,9 @@ class HTTPClient:
         uri = self._uri(path, params)
         return self._request(callback, 'DELETE', uri)
 
+    def close(self):
+        self._connector.close()
+
 
 class Consul(base.Consul):
 
@@ -58,3 +61,7 @@ class Consul(base.Consul):
 
     def connect(self, host, port, scheme):
         return HTTPClient(host, port, scheme, loop=self._loop)
+
+    def close(self):
+        """Close all opened http connections"""
+        self.http.close()


### PR DESCRIPTION
Add new method ``close`` to ``consul.aio.Consul``, to finalize all existing http connections in ``aiohttp.TCPConnector``. Should fix #47

Please review.