### PR TITLE
Allow ALC creation with explicit ID.

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -1429,7 +1429,12 @@ class Consul(object):
             return self.agent.http.get(
                 callback, '/v1/acl/info/%s' % acl_id, params=params)
 
-        def create(self, name=None, type='client', rules=None, token=None):
+        def create(self,
+                   name=None,
+                   type='client',
+                   rules=None,
+                   acl_id=None,
+                   token=None):
             """
             Creates a new ACL token. This is a privileged endpoint, and
             requires a management token. *token* will override this client's
@@ -1478,6 +1483,8 @@ class Consul(object):
                 assert isinstance(rules, str), \
                     'Only HCL encoded strings supported for the moment'
                 payload['Rules'] = rules
+            if acl_id:
+                payload['ID'] = acl_id
 
             if payload:
                 data = json.dumps(payload)


### PR DESCRIPTION
Support creation of ALCs with explicit ID.

Documentation: https://www.consul.io/docs/agent/http/acl.html
```
The ID field may be provided, and if omitted a random UUID will be
generated. The security of the ACL system depends on the difficulty of
guessing the token. Tokens should not be generated in a predictable
manner or with too little entropy.
```
