### PR TITLE
deduplicate query string

### DIFF
--- a/consul/std.py
+++ b/consul/std.py
@@ -35,7 +35,7 @@ class HTTPClient(object):
 
     def delete(self, callback, path, params=None):
         uri = self.uri(path, params)
-        return callback(self.response(requests.delete(uri, params=params)))
+        return callback(self.response(requests.delete(uri)))
 
 
 class Consul(base.Consul):


### PR DESCRIPTION
On using consul.kv.delete() with requests, args sent in the query string were sent twice.