### PR TITLE
Support 'wait' param for all blocking queries

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -298,9 +298,9 @@ class Consul(object):
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
 
-            *wait* the maximum duration to wait (e.g. '10ms') to retrieve
+            *wait* the maximum duration to wait (e.g. '10s') to retrieve
             a given index. this parameter is only applied if *index* is also
-            specified. the wait time by default is 10 minutes.
+            specified. the wait time by default is 5 minutes.
 
             *token* is an optional `ACL token`_ to apply to this request.
 
@@ -897,7 +897,7 @@ class Consul(object):
             return self.agent.http.get(
                 lambda x: json.loads(x.body), '/v1/catalog/datacenters')
 
-        def nodes(self, index=None, consistency=None, dc=None):
+        def nodes(self, index=None, wait=None, consistency=None, dc=None):
             """
             Returns a tuple of (*index*, *nodes*) of all nodes known
             about in the *dc* datacenter. *dc* defaults to the current
@@ -905,6 +905,10 @@ class Consul(object):
 
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
+
+            *wait* the maximum duration to wait (e.g. '10s') to retrieve
+            a given index. this parameter is only applied if *index* is also
+            specified. the wait time by default is 5 minutes.
 
             *consistency* can be either 'default', 'consistent' or 'stale'. if
             not specified *consistency* will the consistency level this client
@@ -929,6 +933,8 @@ class Consul(object):
                 params['dc'] = dc
             if index:
                 params['index'] = index
+                if wait:
+                    params['wait'] = wait
             consistency = consistency or self.agent.consistency
             if consistency in ('consistent', 'stale'):
                 params[consistency] = '1'
@@ -936,7 +942,7 @@ class Consul(object):
                 callback(is_json=True, index=True),
                 '/v1/catalog/nodes', params=params)
 
-        def services(self, index=None, consistency=None, dc=None):
+        def services(self, index=None, wait=None, consistency=None, dc=None):
             """
             Returns a tuple of (*index*, *services*) of all services known
             about in the *dc* datacenter. *dc* defaults to the current
@@ -944,6 +950,10 @@ class Consul(object):
 
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
+
+            *wait* the maximum duration to wait (e.g. '10s') to retrieve
+            a given index. this parameter is only applied if *index* is also
+            specified. the wait time by default is 5 minutes.
 
             *consistency* can be either 'default', 'consistent' or 'stale'. if
             not specified *consistency* will the consistency level this client
@@ -969,6 +979,8 @@ class Consul(object):
                 params['dc'] = dc
             if index:
                 params['index'] = index
+                if wait:
+                    params['wait'] = wait
             consistency = consistency or self.agent.consistency
             if consistency in ('consistent', 'stale'):
                 params[consistency] = '1'
@@ -976,13 +988,17 @@ class Consul(object):
                 callback(is_json=True, index=True),
                 '/v1/catalog/services', params=params)
 
-        def node(self, node, index=None, consistency=None, dc=None):
+        def node(self, node, index=None, wait=None, consistency=None, dc=None):
             """
             Returns a tuple of (*index*, *services*) of all services provided
             by *node*.
 
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
+
+            *wait* the maximum duration to wait (e.g. '10s') to retrieve
+            a given index. this parameter is only applied if *index* is also
+            specified. the wait time by default is 5 minutes.
 
             *consistency* can be either 'default', 'consistent' or 'stale'. if
             not specified *consistency* will the consistency level this client
@@ -1022,6 +1038,8 @@ class Consul(object):
                 params['dc'] = dc
             if index:
                 params['index'] = index
+                if wait:
+                    params['wait'] = wait
             consistency = consistency or self.agent.consistency
             if consistency in ('consistent', 'stale'):
                 params[consistency] = '1'
@@ -1033,6 +1051,7 @@ class Consul(object):
                 self,
                 service,
                 index=None,
+                wait=None,
                 tag=None,
                 consistency=None,
                 dc=None):
@@ -1043,6 +1062,10 @@ class Consul(object):
 
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
+
+            *wait* the maximum duration to wait (e.g. '10s') to retrieve
+            a given index. this parameter is only applied if *index* is also
+            specified. the wait time by default is 5 minutes.
 
             If *tag* is provided, the list of nodes returned will be filtered
             by that tag.
@@ -1072,6 +1095,8 @@ class Consul(object):
                 params['tag'] = tag
             if index:
                 params['index'] = index
+                if wait:
+                    params['wait'] = wait
             consistency = consistency or self.agent.consistency
             if consistency in ('consistent', 'stale'):
                 params[consistency] = '1'
@@ -1089,6 +1114,7 @@ class Consul(object):
         def service(self,
                     service,
                     index=None,
+                    wait=None,
                     passing=None,
                     tag=None,
                     dc=None):
@@ -1097,6 +1123,10 @@ class Consul(object):
 
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
+
+            *wait* the maximum duration to wait (e.g. '10s') to retrieve
+            a given index. this parameter is only applied if *index* is also
+            specified. the wait time by default is 5 minutes.
 
             *nodes* are the nodes providing the given service.
 
@@ -1109,8 +1139,10 @@ class Consul(object):
             datacenter.
             """
             params = {}
-            if index is not None:
+            if index:
                 params['index'] = index
+                if wait:
+                    params['wait'] = wait
             if passing:
                 params['passing'] = '1'
             if tag is not None:
@@ -1127,7 +1159,7 @@ class Consul(object):
                 callback,
                 '/v1/health/service/%s' % service, params=params)
 
-        def state(self, name, index=None, dc=None):
+        def state(self, name, index=None, wait=None, dc=None):
             """
             Returns a tuple of (*index*, *nodes*)
 
@@ -1140,6 +1172,10 @@ class Consul(object):
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
 
+            *wait* the maximum duration to wait (e.g. '10s') to retrieve
+            a given index. this parameter is only applied if *index* is also
+            specified. the wait time by default is 5 minutes.
+
             *dc* is the datacenter of the node and defaults to this agents
             datacenter.
 
@@ -1149,6 +1185,8 @@ class Consul(object):
             params = {}
             if index:
                 params['index'] = index
+                if wait:
+                    params['wait'] = wait
             dc = dc or self.agent.dc
             if dc:
                 params['dc'] = dc
@@ -1161,12 +1199,16 @@ class Consul(object):
                 callback,
                 '/v1/health/state/%s' % name, params=params)
 
-        def node(self, node, index=None, dc=None):
+        def node(self, node, index=None, wait=None, dc=None):
             """
             Returns a tuple of (*index*, *checks*)
 
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
+
+            *wait* the maximum duration to wait (e.g. '10s') to retrieve
+            a given index. this parameter is only applied if *index* is also
+            specified. the wait time by default is 5 minutes.
 
             *dc* is the datacenter of the node and defaults to this agents
             datacenter.
@@ -1176,6 +1218,8 @@ class Consul(object):
             params = {}
             if index:
                 params['index'] = index
+                if wait:
+                    params['wait'] = wait
             dc = dc or self.agent.dc
             if dc:
                 params['dc'] = dc
@@ -1275,7 +1319,7 @@ class Consul(object):
                 callback(is_200=True),
                 '/v1/session/destroy/%s' % session_id, params=params)
 
-        def list(self, index=None, consistency=None, dc=None):
+        def list(self, index=None, wait=None, consistency=None, dc=None):
             """
             Returns a tuple of (*index*, *sessions*) of all active sessions in
             the *dc* datacenter. *dc* defaults to the current datacenter of
@@ -1283,6 +1327,10 @@ class Consul(object):
 
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
+
+            *wait* the maximum duration to wait (e.g. '10s') to retrieve
+            a given index. this parameter is only applied if *index* is also
+            specified. the wait time by default is 5 minutes.
 
             *consistency* can be either 'default', 'consistent' or 'stale'. if
             not specified *consistency* will the consistency level this client
@@ -1309,6 +1357,8 @@ class Consul(object):
                 params['dc'] = dc
             if index:
                 params['index'] = index
+                if wait:
+                    params['wait'] = wait
             consistency = consistency or self.agent.consistency
             if consistency in ('consistent', 'stale'):
                 params[consistency] = '1'
@@ -1316,13 +1366,17 @@ class Consul(object):
                 callback(is_json=True, index=True),
                 '/v1/session/list', params=params)
 
-        def node(self, node, index=None, consistency=None, dc=None):
+        def node(self, node, index=None, wait=None, consistency=None, dc=None):
             """
             Returns a tuple of (*index*, *sessions*) as per *session.list*, but
             filters the sessions returned to only those active for *node*.
 
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
+
+            *wait* the maximum duration to wait (e.g. '10s') to retrieve
+            a given index. this parameter is only applied if *index* is also
+            specified. the wait time by default is 5 minutes.
 
             *consistency* can be either 'default', 'consistent' or 'stale'. if
             not specified *consistency* will the consistency level this client
@@ -1334,6 +1388,8 @@ class Consul(object):
                 params['dc'] = dc
             if index:
                 params['index'] = index
+                if wait:
+                    params['wait'] = wait
             consistency = consistency or self.agent.consistency
             if consistency in ('consistent', 'stale'):
                 params[consistency] = '1'
@@ -1341,7 +1397,12 @@ class Consul(object):
                 callback(is_json=True, index=True),
                 '/v1/session/node/%s' % node, params=params)
 
-        def info(self, session_id, index=None, consistency=None, dc=None):
+        def info(self,
+                 session_id,
+                 index=None,
+                 wait=None,
+                 consistency=None,
+                 dc=None):
             """
             Returns a tuple of (*index*, *session*) for the session
             *session_id* in the *dc* datacenter. *dc* defaults to the current
@@ -1350,6 +1411,10 @@ class Consul(object):
             *index* is the current Consul index, suitable for making subsequent
             calls to wait for changes since this query was last run.
 
+            *wait* the maximum duration to wait (e.g. '10s') to retrieve
+            a given index. this parameter is only applied if *index* is also
+            specified. the wait time by default is 5 minutes.
+
             *consistency* can be either 'default', 'consistent' or 'stale'. if
             not specified *consistency* will the consistency level this client
             was configured with.
@@ -1360,6 +1425,8 @@ class Consul(object):
                 params['dc'] = dc
             if index:
                 params['index'] = index
+                if wait:
+                    params['wait'] = wait
             consistency = consistency or self.agent.consistency
             if consistency in ('consistent', 'stale'):
                 params[consistency] = '1'


### PR DESCRIPTION
I manually confirmed that it works for all the blocking endpoints.  I also adjusted the existing wait param comment to match Consul's docs (5m is the default wait timeout, not 10m), and duplicated it as necessary.