### PR TITLE
Use requests.session for performance

### DIFF
--- a/consul/std.py
+++ b/consul/std.py
@@ -14,6 +14,7 @@ class HTTPClient(object):
         self.port = port
         self.scheme = scheme
         self.base_uri = '%s://%s:%s' % (self.scheme, self.host, self.port)
+        self.session = requests.session()
 
     def response(self, response):
         return base.Response(
@@ -27,15 +28,15 @@ class HTTPClient(object):
 
     def get(self, callback, path, params=None):
         uri = self.uri(path, params)
-        return callback(self.response(requests.get(uri)))
+        return callback(self.response(self.session.get(uri)))
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
-        return callback(self.response(requests.put(uri, data=data)))
+        return callback(self.response(self.session.put(uri, data=data)))
 
     def delete(self, callback, path, params=None):
         uri = self.uri(path, params)
-        return callback(self.response(requests.delete(uri, params=params)))
+        return callback(self.response(self.session.delete(uri, params=params)))
 
 
 class Consul(base.Consul):


### PR DESCRIPTION
By using a persistent requests.session, requests can use [Keep-Alives](http://docs.python-requests.org/en/latest/user/advanced/#keep-alive), resulting in better performance, when the client is doing repeated requests to Consul.

When testing the [ansible consul_io inventory script](https://github.com/ansible/ansible/blob/devel/contrib/inventory/consul_io.py), it takes ~12 seconds (because it does 774 HTTP requests!) to hit all nodes without this, and about ~8 seconds with this, which is a pretty decent speedup.

Cc: @sgargan, @sudarkoff, @aconrad