### PR TITLE
Improve error when a HTTP 503 status code is returned

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -107,8 +107,8 @@ def callback(
         allow_404=True):
 
     def cb(response):
-        if response.code == 500:
-            raise ConsulException(response.body)
+        if response.code >= 500 and response.code < 600:
+            raise ConsulException("%d %s" % (response.code, response.body))
         if response.code == 403:
             raise ACLPermissionDenied(response.body)
         if response.code == 404 and not allow_404:


### PR DESCRIPTION
Example:
```
File "/usr/local/lib/python2.7/dist-packages/blaze_cli-0.1-py2.7.egg/blazecli/commands/common.py", line 25, in consul_get_service
    index, services = consul.catalog.service(servicename)
  File "/usr/local/lib/python2.7/dist-packages/consul/base.py", line 1108, in service
    '/v1/catalog/service/%s' % service, params=params)
  File "/usr/local/lib/python2.7/dist-packages/consul/std.py", line 34, in get
    self.session.get(uri, verify=self.verify)))
  File "/usr/local/lib/python2.7/dist-packages/consul/base.py", line 119, in cb
    data = json.loads(response.body)
  File "/usr/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

It would be nice to have a separate message when no response body is received, or otherwise log the JSON string that could not be decoded.