### PR TITLE
Use native consul time values on Session.create

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -1244,7 +1244,7 @@ class Consul(object):
                 name=None,
                 node=None,
                 checks=None,
-                lock_delay=15,
+                lock_delay='15s',
                 behavior='release',
                 ttl=None,
                 dc=None):
@@ -1291,15 +1291,14 @@ class Consul(object):
                 data['node'] = node
             if checks is not None:
                 data['checks'] = checks
-            if lock_delay != 15:
-                data['lockdelay'] = '%ss' % lock_delay
+            if lock_delay != '15s':
+                data['lockdelay'] = lock_delay
             assert behavior in ('release', 'delete'), \
                 'behavior must be release or delete'
             if behavior != 'release':
                 data['behavior'] = behavior
             if ttl:
-                assert 10 <= ttl <= 3600
-                data['ttl'] = '%ss' % ttl
+                data['ttl'] = ttl
             if data:
                 data = json.dumps(data)
             else:


### PR DESCRIPTION
Since the consul API raises an error when the session TTL is below 10 or above 3600 seconds we don't have to do a check.
The reason why this should not be done is to allow default time values like "5s", "30m" or "2h". The same with lock delay.

Note that this could break some code which is using this lib since consul assumes milliseconds per default when no other unit is given.
