### PR TITLE
Use standard consul environment variables to override configuration

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -162,8 +162,9 @@ class Consul(object):
 
         if os.getenv('CONSUL_HTTP_ADDR'):
             host, port = os.getenv('CONSUL_HTTP_ADDR').split(':')
+
         self.http = self.connect(host, port, scheme, verify)
-        self.token = token
+        self.token = os.getenv('CONSUL_HTTP_TOKEN', token)
         self.scheme = scheme
         self.dc = dc
         assert consistency in ('default', 'consistent', 'stale'), \

--- a/consul/base.py
+++ b/consul/base.py
@@ -162,6 +162,8 @@ class Consul(object):
 
         if os.getenv('CONSUL_HTTP_ADDR'):
             host, port = os.getenv('CONSUL_HTTP_ADDR').split(':')
+        if os.getenv('CONSUL_HTTP_SSL') != None:
+            scheme = 'https' if os.getenv('CONSUL_HTTP_SSL') else 'http'
 
         self.http = self.connect(host, port, scheme, verify)
         self.token = os.getenv('CONSUL_HTTP_TOKEN', token)

--- a/consul/base.py
+++ b/consul/base.py
@@ -2,6 +2,7 @@ import collections
 import logging
 import base64
 import json
+import os
 
 import six
 
@@ -159,6 +160,8 @@ class Consul(object):
 
         # TODO: Status
 
+        if os.getenv('CONSUL_HTTP_ADDR'):
+            host, port = os.getenv('CONSUL_HTTP_ADDR').split(':')
         self.http = self.connect(host, port, scheme, verify)
         self.token = token
         self.scheme = scheme

--- a/consul/base.py
+++ b/consul/base.py
@@ -164,6 +164,8 @@ class Consul(object):
             host, port = os.getenv('CONSUL_HTTP_ADDR').split(':')
         if os.getenv('CONSUL_HTTP_SSL') != None:
             scheme = 'https' if os.getenv('CONSUL_HTTP_SSL') else 'http'
+        if os.getenv('CONSUL_HTTP_SSL_VERIFY') != None:
+            verify = os.getenv('CONSUL_HTTP_SSL_VERIFY')
 
         self.http = self.connect(host, port, scheme, verify)
         self.token = os.getenv('CONSUL_HTTP_TOKEN', token)

--- a/consul/base.py
+++ b/consul/base.py
@@ -162,8 +162,9 @@ class Consul(object):
 
         if os.getenv('CONSUL_HTTP_ADDR'):
             host, port = os.getenv('CONSUL_HTTP_ADDR').split(':')
-        if os.getenv('CONSUL_HTTP_SSL') != None:
-            scheme = 'https' if os.getenv('CONSUL_HTTP_SSL') else 'http'
+        use_ssl = os.getenv('CONSUL_HTTP_SSL')
+        if use_ssl is not None:
+            scheme = 'https' if use_ssl == 'true' else 'http'
         if os.getenv('CONSUL_HTTP_SSL_VERIFY') != None:
             verify = os.getenv('CONSUL_HTTP_SSL_VERIFY') == 'true'
 

--- a/consul/base.py
+++ b/consul/base.py
@@ -165,7 +165,7 @@ class Consul(object):
         if os.getenv('CONSUL_HTTP_SSL') != None:
             scheme = 'https' if os.getenv('CONSUL_HTTP_SSL') else 'http'
         if os.getenv('CONSUL_HTTP_SSL_VERIFY') != None:
-            verify = os.getenv('CONSUL_HTTP_SSL_VERIFY')
+            verify = os.getenv('CONSUL_HTTP_SSL_VERIFY') == 'true'
 
         self.http = self.connect(host, port, scheme, verify)
         self.token = os.getenv('CONSUL_HTTP_TOKEN', token)

--- a/consul/base.py
+++ b/consul/base.py
@@ -165,7 +165,7 @@ class Consul(object):
         use_ssl = os.getenv('CONSUL_HTTP_SSL')
         if use_ssl is not None:
             scheme = 'https' if use_ssl == 'true' else 'http'
-        if os.getenv('CONSUL_HTTP_SSL_VERIFY') != None:
+        if os.getenv('CONSUL_HTTP_SSL_VERIFY') is not None:
             verify = os.getenv('CONSUL_HTTP_SSL_VERIFY') == 'true'
 
         self.http = self.connect(host, port, scheme, verify)


### PR DESCRIPTION
Other Hashicorp tools, envconsul and consul-template, use this set of environment variables to provide configuration for themselves and other consul tools they're integrated with.  I've implemented them as overrides to what is normally passed in to the constructor.  That seems to make sense since an application can be configured to use the default host/port but then be overridden by providing CONSUL_HTTP_ADDR.