### PR TITLE
Add bumpversion support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,17 @@
+[bumpversion]
+commit = True
+tag = True
+current_version = 0.6.1-dev
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
+serialize = 
+	{major}.{minor}.{patch}-{release}
+	{major}.{minor}.{patch}
+
+[bumpversion:file:consul/__init__.py]
+
+[bumpversion:part:release]
+optional_value = gamma
+values = 
+	dev
+	gamma
+

--- a/README.rst
+++ b/README.rst
@@ -50,3 +50,17 @@ Status
 There's a few API endpoints still to go to expose all features available in
 Consul v0.6.0. If you need an endpoint that's not in the documentation, just
 open an issue and I'll try and add it straight away.
+
+Releases
+--------
+
+.. code:: bash
+
+    # release the current version, eg: 0.6.1-dev -> 0.6.1
+    bumpversion release
+
+    # prepare the next patch (z-stream) version, eg: 0.6.1 -> 0.6.2-dev
+    bumpversion --no-tag patch
+
+    # else, prepare the next minor (y-stream) version, eg: 0.6.1 -> 0.7.0-dev
+    bumpversion --no-tag minor

--- a/consul/__init__.py
+++ b/consul/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.6.0'
+__version__ = '0.6.1-dev'
 
 from consul.std import Consul
 


### PR DESCRIPTION
Proposing that the project use bumpversion to manage versions/release.

This also resolves #91.