### PR TITLE
Add configurable request timeouts 

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -417,7 +417,10 @@ class Consul(object):
 
             return self.agent.http.put(
                 CB.json(),
-                '/v1/event/fire/%s' % name, params=params, data=body, timeout=timeout)
+                '/v1/event/fire/%s' % name, 
+                params=params, 
+                data=body, 
+                timeout=timeout)
 
         def list(
                 self,

--- a/consul/base.py
+++ b/consul/base.py
@@ -247,13 +247,14 @@ class CB(object):
 
 class HTTPClient(six.with_metaclass(abc.ABCMeta, object)):
     def __init__(self, host='127.0.0.1', port=8500, scheme='http',
-                 verify=True, cert=None):
+                 verify=True, cert=None, timeout=None):
         self.host = host
         self.port = port
         self.scheme = scheme
         self.verify = verify
         self.base_uri = '%s://%s:%s' % (self.scheme, self.host, self.port)
         self.cert = cert
+        self.timeout = timeout
 
     def uri(self, path, params=None):
         uri = self.base_uri + urllib.parse.quote(path, safe='/:')
@@ -288,7 +289,8 @@ class Consul(object):
             consistency='default',
             dc=None,
             verify=True,
-            cert=None):
+            cert=None,
+            timeout=None):
         """
         *token* is an optional `ACL token`_. If supplied it will be used by
         default for all requests made with this client session. It's still
@@ -306,6 +308,8 @@ class Consul(object):
         *verify* is whether to verify the SSL certificate for HTTPS requests
 
         *cert* client side certificates for HTTPS requests
+        
+        *timeout* is the timeout applied to HTTP requests
         """
 
         # TODO: Status
@@ -323,7 +327,8 @@ class Consul(object):
         if os.getenv('CONSUL_HTTP_SSL_VERIFY') is not None:
             verify = os.getenv('CONSUL_HTTP_SSL_VERIFY') == 'true'
 
-        self.http = self.connect(host, port, scheme, verify, cert)
+        self.timeout = timeout
+        self.http = self.connect(host, port, scheme, verify, cert, timeout)
         self.token = os.getenv('CONSUL_HTTP_TOKEN', token)
         self.scheme = scheme
         self.dc = dc
@@ -368,7 +373,8 @@ class Consul(object):
                 node=None,
                 service=None,
                 tag=None,
-                token=None):
+                token=None,
+                timeout=None):
             """
             Sends an event to Consul's gossip protocol.
 
@@ -390,6 +396,11 @@ class Consul(object):
             *token* is an optional `ACL token`_ to apply to this request. If
             the token's policy is not allowed to fire an event of this *name*
             an *ACLPermissionDenied* exception will be raised.
+            
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
             """
             assert not name.startswith('/'), \
                 'keys should not start with a forward slash'
@@ -406,13 +417,14 @@ class Consul(object):
 
             return self.agent.http.put(
                 CB.json(),
-                '/v1/event/fire/%s' % name, params=params, data=body)
+                '/v1/event/fire/%s' % name, params=params, data=body, timeout=timeout)
 
         def list(
                 self,
                 name=None,
                 index=None,
-                wait=None):
+                wait=None,
+                timeout=None):
             """
             Returns a tuple of (*index*, *events*)
                 Note: Since Consul's event protocol uses gossip, there is no
@@ -429,6 +441,11 @@ class Consul(object):
             *wait* the maximum duration to wait (e.g. '10s') to retrieve
             a given index. This parameter is only applied if *index* is also
             specified. the wait time by default is 5 minutes.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             Consul agents only buffer the most recent entries. The current
             buffer size is 256, but this value could change in the future.
@@ -457,7 +474,7 @@ class Consul(object):
                     params.append(('wait', wait))
             return self.agent.http.get(
                 CB.json(index=True, decode='Payload'),
-                '/v1/event/list', params=params)
+                '/v1/event/list', params=params, timeout=timeout)
 
     class KV(object):
         """
@@ -478,7 +495,8 @@ class Consul(object):
                 consistency=None,
                 keys=False,
                 separator=None,
-                dc=None):
+                dc=None,
+                timeout=None):
             """
             Returns a tuple of (*index*, *value[s]*)
 
@@ -497,6 +515,11 @@ class Consul(object):
 
             *dc* is the optional datacenter that you wish to communicate with.
             If None is provided, defaults to the agent's datacenter.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             The *value* returned is for the specified key, or if *recurse* is
             True a list of *values* for all keys with the given prefix is
@@ -551,7 +574,7 @@ class Consul(object):
             return self.agent.http.get(
                 CB.json(index=True, decode=decode, one=one),
                 '/v1/kv/%s' % key,
-                params=params)
+                params=params, timeout=timeout)
 
         def put(
                 self,
@@ -562,7 +585,8 @@ class Consul(object):
                 acquire=None,
                 release=None,
                 token=None,
-                dc=None):
+                dc=None,
+                timeout=None):
             """
             Sets *key* to the given *value*.
 
@@ -593,6 +617,11 @@ class Consul(object):
             *dc* is the optional datacenter that you wish to communicate with.
             If None is provided, defaults to the agent's datacenter.
 
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
+
             The return value is simply either True or False. If False is
             returned, then the update has not taken place.
             """
@@ -618,9 +647,9 @@ class Consul(object):
             if dc:
                 params.append(('dc', dc))
             return self.agent.http.put(
-                CB.json(), '/v1/kv/%s' % key, params=params, data=value)
+                CB.json(), '/v1/kv/%s' % key, params=params, data=value, timeout=timeout)
 
-        def delete(self, key, recurse=None, cas=None, token=None, dc=None):
+        def delete(self, key, recurse=None, cas=None, token=None, dc=None, timeout=None):
             """
             Deletes a single key or if *recurse* is True, all keys sharing a
             prefix.
@@ -638,6 +667,11 @@ class Consul(object):
 
             *dc* is the optional datacenter that you wish to communicate with.
             If None is provided, defaults to the agent's datacenter.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
             """
             assert not key.startswith('/'), \
                 'keys should not start with a forward slash'
@@ -655,7 +689,7 @@ class Consul(object):
                 params.append(('dc', dc))
 
             return self.agent.http.delete(
-                CB.json(), '/v1/kv/%s' % key, params=params)
+                CB.json(), '/v1/kv/%s' % key, params=params, timeout=timeout)
 
     class Txn(object):
         """
@@ -702,14 +736,24 @@ class Consul(object):
             self.service = Consul.Agent.Service(agent)
             self.check = Consul.Agent.Check(agent)
 
-        def self(self):
+        def self(self,timeout=None):
             """
             Returns configuration of the local agent and member information.
-            """
-            return self.agent.http.get(CB.json(), '/v1/agent/self')
 
-        def services(self):
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
             """
+            return self.agent.http.get(CB.json(), '/v1/agent/self', timeout=timeout)
+
+        def services(self,timeout=None):
+            """
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
+
             Returns all the services that are registered with the local agent.
             These services were either provided through configuration files, or
             added dynamically using the HTTP API. It is important to note that
@@ -719,10 +763,15 @@ class Consul(object):
             anti-entropy, so in most situations everything will be in sync
             within a few seconds.
             """
-            return self.agent.http.get(CB.json(), '/v1/agent/services')
+            return self.agent.http.get(CB.json(), '/v1/agent/services', timeout=timeout)
 
-        def checks(self):
+        def checks(self,timeout=None):
             """
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
+
             Returns all the checks that are registered with the local agent.
             These checks were either provided through configuration files, or
             added dynamically using the HTTP API. Similar to services,
@@ -732,10 +781,15 @@ class Consul(object):
             anti-entropy, so in most situations everything will be in sync
             within a few seconds.
             """
-            return self.agent.http.get(CB.json(), '/v1/agent/checks')
+            return self.agent.http.get(CB.json(), '/v1/agent/checks', timeout=timeout)
 
-        def members(self, wan=False):
+        def members(self, wan=False, timeout=None):
             """
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
+
             Returns all the members that this agent currently sees. This may
             vary by agent, use the nodes api of Catalog to retrieve a cluster
             wide consistent view of members.
@@ -748,12 +802,17 @@ class Consul(object):
             if wan:
                 params.append(('wan', 1))
             return self.agent.http.get(
-                CB.json(), '/v1/agent/members', params=params)
+                CB.json(), '/v1/agent/members', params=params, timeout=timeout)
 
-        def maintenance(self, enable, reason=None):
+        def maintenance(self, enable, reason=None, timeout=None):
             """
             The node maintenance endpoint can place the agent into
             "maintenance mode".
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             *enable* is either 'true' or 'false'. 'true' enables maintenance
             mode, 'false' disables maintenance mode.
@@ -769,12 +828,17 @@ class Consul(object):
                 params.append(('reason', reason))
 
             return self.agent.http.put(
-                CB.bool(), '/v1/agent/maintenance', params=params)
+                CB.bool(), '/v1/agent/maintenance', params=params, timeout=timeout)
 
-        def join(self, address, wan=False):
+        def join(self, address, wan=False, timeout=None):
             """
             This endpoint instructs the agent to attempt to connect to a
             given address.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             *address* is the ip to connect to.
 
@@ -789,9 +853,9 @@ class Consul(object):
                 params.append(('wan', 1))
 
             return self.agent.http.put(
-                CB.bool(), '/v1/agent/join/%s' % address, params=params)
+                CB.bool(), '/v1/agent/join/%s' % address, params=params, timeout=timeout)
 
-        def force_leave(self, node):
+        def force_leave(self, node, timeout=None):
             """
             This endpoint instructs the agent to force a node into the left
             state. If a node fails unexpectedly, then it will be in a failed
@@ -801,10 +865,15 @@ class Consul(object):
             entries to be removed.
 
             *node* is the node to change state for.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
             """
 
             return self.agent.http.put(
-                CB.bool(), '/v1/agent/force-leave/%s' % node)
+                CB.bool(), '/v1/agent/force-leave/%s' % node, timeout=timeout)
 
         class Service(object):
             def __init__(self, agent):
@@ -862,6 +931,11 @@ class Consul(object):
                 servers.
                 for more information
                 https://www.consul.io/docs/agent/services.html
+                
+                *timeout* - If *check* is specified, this argument is
+                the optional timeout for HTTP requests made to Consul. If
+                *check* is not specified, this argument is treated as the
+                deprecated *timeout* argument above which creates a check.
                 """
 
                 payload = {}
@@ -879,9 +953,14 @@ class Consul(object):
                     payload['tags'] = tags
                 if meta:
                     payload['meta'] = meta
+
+                # If new 'check' object is used, treat timeout field as 
+                # http timeout for requests. Otherwise set default timeout
+                http_timeout = None
+
                 if check:
                     payload['check'] = check
-
+                    http_timeout = timeout
                 else:
                     payload.update(Check._compat(
                         script=script,
@@ -899,18 +978,23 @@ class Consul(object):
                     CB.bool(),
                     '/v1/agent/service/register',
                     params=params,
-                    data=json.dumps(payload))
+                    data=json.dumps(payload), timeout=http_timeout)
 
-            def deregister(self, service_id):
+            def deregister(self, service_id, timeout=None):
                 """
                 Used to remove a service from the local agent. The agent will
                 take care of deregistering the service with the Catalog. If
                 there is an associated check, that is also deregistered.
+
+                *timeout* is the optional timeout for HTTP requests made to Consul.
+                If None is provided, defaults to timeout value set when
+                instantiating consul instance, or the default value set in
+                requests.
                 """
                 return self.agent.http.put(
-                    CB.bool(), '/v1/agent/service/deregister/%s' % service_id)
+                    CB.bool(), '/v1/agent/service/deregister/%s' % service_id, timeout=timeout)
 
-            def maintenance(self, service_id, enable, reason=None):
+            def maintenance(self, service_id, enable, reason=None, timeout=None):
                 """
                 The service maintenance endpoint allows placing a given service
                 into "maintenance mode".
@@ -923,6 +1007,11 @@ class Consul(object):
 
                 *reason* is an optional string. This is simply to aid human
                 operators.
+
+                *timeout* is the optional timeout for HTTP requests made to Consul.
+                If None is provided, defaults to timeout value set when
+                instantiating consul instance, or the default value set in
+                requests.
                 """
 
                 params = []
@@ -934,7 +1023,8 @@ class Consul(object):
                 return self.agent.http.put(
                     CB.bool(),
                     '/v1/agent/service/maintenance/{0}'.format(service_id),
-                    params=params)
+                    params=params,
+                    timeout=timeout)
 
         class Check(object):
             def __init__(self, agent):
@@ -980,6 +1070,11 @@ class Consul(object):
                 *script*, *interval*, *ttl*, *http*, and *timeout* arguments
                 are deprecated. use *check* instead.
 
+                *timeout* - If *check* is specified, this argument is
+                the optional timeout for HTTP requests made to Consul. If
+                *check* is not specified, this argument is treated as the
+                deprecated *timeout* argument above which creates a check.
+
                 Returns *True* on success.
                 """
                 payload = {'name': name}
@@ -987,7 +1082,12 @@ class Consul(object):
                 assert check or script or ttl or http, \
                     'check is required'
 
+                # If new 'check' object is used, treat timeout field as 
+                # http timeout for requests. Otherwise set default timeout
+                http_timeout = None
+
                 if check:
+                    http_timeout = timeout
                     payload.update(check)
 
                 else:
@@ -1014,20 +1114,32 @@ class Consul(object):
                     CB.bool(),
                     '/v1/agent/check/register',
                     params=params,
-                    data=json.dumps(payload))
+                    data=json.dumps(payload),
+                    timeout=http_timeout)
 
-            def deregister(self, check_id):
+            def deregister(self, check_id, timeout=None):
                 """
                 Remove a check from the local agent.
+
+                *timeout* is the optional timeout for HTTP requests made to Consul.
+                If None is provided, defaults to timeout value set when
+                instantiating consul instance, or the default value set in
+                requests.
                 """
                 return self.agent.http.put(
                     CB.bool(),
-                    '/v1/agent/check/deregister/%s' % check_id)
+                    '/v1/agent/check/deregister/%s' % check_id, 
+                    timeout=timeout)
 
-            def ttl_pass(self, check_id, notes=None):
+            def ttl_pass(self, check_id, notes=None, timeout=None):
                 """
                 Mark a ttl based check as passing. Optional notes can be
                 attached to describe the status of the check.
+
+                *timeout* is the optional timeout for HTTP requests made to Consul.
+                If None is provided, defaults to timeout value set when
+                instantiating consul instance, or the default value set in
+                requests.
                 """
                 params = []
                 if notes:
@@ -1036,13 +1148,19 @@ class Consul(object):
                 return self.agent.http.put(
                     CB.bool(),
                     '/v1/agent/check/pass/%s' % check_id,
-                    params=params)
+                    params=params,
+                    timeout=timeout)
 
-            def ttl_fail(self, check_id, notes=None):
+            def ttl_fail(self, check_id, notes=None, timeout=None):
                 """
                 Mark a ttl based check as failing. Optional notes can be
                 attached to describe why check is failing. The status of the
                 check will be set to critical and the ttl clock will be reset.
+
+                *timeout* is the optional timeout for HTTP requests made to Consul.
+                If None is provided, defaults to timeout value set when
+                instantiating consul instance, or the default value set in
+                requests.
                 """
                 params = []
                 if notes:
@@ -1051,13 +1169,19 @@ class Consul(object):
                 return self.agent.http.put(
                     CB.bool(),
                     '/v1/agent/check/fail/%s' % check_id,
-                    params=params)
+                    params=params,
+                    timeout=timeout)
 
-            def ttl_warn(self, check_id, notes=None):
+            def ttl_warn(self, check_id, notes=None, timeout=None):
                 """
                 Mark a ttl based check with warning. Optional notes can be
                 attached to describe the warning. The status of the
                 check will be set to warn and the ttl clock will be reset.
+
+                *timeout* is the optional timeout for HTTP requests made to Consul.
+                If None is provided, defaults to timeout value set when
+                instantiating consul instance, or the default value set in
+                requests.
                 """
                 params = []
                 if notes:
@@ -1066,7 +1190,8 @@ class Consul(object):
                 return self.agent.http.put(
                     CB.bool(),
                     '/v1/agent/check/warn/%s' % check_id,
-                    params=params)
+                    params=params,
+                    timeout=timeout)
 
     class Catalog(object):
         def __init__(self, agent):
@@ -1079,7 +1204,8 @@ class Consul(object):
                      check=None,
                      dc=None,
                      token=None,
-                     node_meta=None):
+                     node_meta=None,
+                     timeout=None):
             """
             A low level mechanism for directly registering or updating entries
             in the catalog. It is usually recommended to use
@@ -1132,6 +1258,11 @@ class Consul(object):
             *node_meta* is an optional meta data used for filtering, a
             dictionary formatted as {k1:v1, k2:v2}.
 
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
+
             This manipulates the health check entry, but does not setup a
             script or TTL to actually update the status. The full documentation
             is `here <https://consul.io/docs/agent/http.html#catalog>`_.
@@ -1157,16 +1288,17 @@ class Consul(object):
                                    format(nodemeta_name, nodemeta_value)))
             return self.agent.http.put(
                 CB.bool(),
-                '/v1/catalog/register',
                 data=json.dumps(data),
-                params=params)
+                params=params,
+                timeout=None)
 
         def deregister(self,
                        node,
                        service_id=None,
                        check_id=None,
                        dc=None,
-                       token=None):
+                       token=None,
+                       timeout=None):
             """
             A low level mechanism for directly removing entries in the catalog.
             It is usually recommended to use the agent APIs, as they are
@@ -1178,7 +1310,13 @@ class Consul(object):
             and *check_id* should be provided and only that service or check
             will be removed.
 
+
             *token* is an optional `ACL token`_ to apply to this request.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             Returns *True* on success.
             """
@@ -1195,14 +1333,21 @@ class Consul(object):
             if token:
                 data['WriteRequest'] = {'Token': token}
             return self.agent.http.put(
-                CB.bool(), '/v1/catalog/deregister', data=json.dumps(data))
 
-        def datacenters(self):
+                CB.bool(), '/v1/catalog/deregister', data=json.dumps(data),
+                timeout=timeout)
+
+        def datacenters(self, timeout=None):
             """
             Returns all the datacenters that are known by the Consul server.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
             """
             return self.agent.http.get(
-                CB.json(), '/v1/catalog/datacenters')
+                CB.json(), '/v1/catalog/datacenters', timeout=timeout)
 
         def nodes(
                 self,
@@ -1212,7 +1357,8 @@ class Consul(object):
                 dc=None,
                 near=None,
                 token=None,
-                node_meta=None):
+                node_meta=None,
+                timeout=None):
             """
             Returns a tuple of (*index*, *nodes*) of all nodes known
             about in the *dc* datacenter. *dc* defaults to the current
@@ -1236,6 +1382,11 @@ class Consul(object):
 
             *node_meta* is an optional meta data used for filtering, a
             dictionary formatted as {k1:v1, k2:v2}.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             The response looks like this::
 
@@ -1271,7 +1422,7 @@ class Consul(object):
                     params.append(('node-meta', '{0}:{1}'.
                                    format(nodemeta_name, nodemeta_value)))
             return self.agent.http.get(
-                CB.json(index=True), '/v1/catalog/nodes', params=params)
+                CB.json(index=True), '/v1/catalog/nodes', params=params, timeout=timeout)
 
         def services(self,
                      index=None,
@@ -1279,7 +1430,8 @@ class Consul(object):
                      consistency=None,
                      dc=None,
                      token=None,
-                     node_meta=None):
+                     node_meta=None,
+                     timeout=None):
             """
             Returns a tuple of (*index*, *services*) of all services known
             about in the *dc* datacenter. *dc* defaults to the current
@@ -1300,6 +1452,11 @@ class Consul(object):
 
             *node_meta* is an optional meta data used for filtering, a
             dictionary formatted as {k1:v1, k2:v2}.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             The response looks like this::
 
@@ -1334,7 +1491,8 @@ class Consul(object):
                     params.append(('node-meta', '{0}:{1}'.
                                    format(nodemeta_name, nodemeta_value)))
             return self.agent.http.get(
-                CB.json(index=True), '/v1/catalog/services', params=params)
+                CB.json(index=True), '/v1/catalog/services', params=params,
+                timeout=timeout)
 
         def node(self,
                  node,
@@ -1342,7 +1500,8 @@ class Consul(object):
                  wait=None,
                  consistency=None,
                  dc=None,
-                 token=None):
+                 token=None,
+                 timeout=None):
             """
             Returns a tuple of (*index*, *services*) of all services provided
             by *node*.
@@ -1362,6 +1521,11 @@ class Consul(object):
             datacenter.
 
             *token* is an optional `ACL token`_ to apply to this request.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             The response looks like this::
 
@@ -1405,7 +1569,7 @@ class Consul(object):
             return self.agent.http.get(
                 CB.json(index=True),
                 '/v1/catalog/node/%s' % node,
-                params=params)
+                params=params, timeout=timeout)
 
         def service(
                 self,
@@ -1417,7 +1581,8 @@ class Consul(object):
                 dc=None,
                 near=None,
                 token=None,
-                node_meta=None):
+                node_meta=None,
+                timeout=None):
             """
             Returns a tuple of (*index*, *nodes*) of the nodes providing
             *service* in the *dc* datacenter. *dc* defaults to the current
@@ -1444,6 +1609,11 @@ class Consul(object):
 
             *node_meta* is an optional meta data used for filtering, a
             dictionary formatted as {k1:v1, k2:v2}.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             The response looks like this::
 
@@ -1483,7 +1653,7 @@ class Consul(object):
             return self.agent.http.get(
                 CB.json(index=True),
                 '/v1/catalog/service/%s' % service,
-                params=params)
+                params=params, timeout=timeout)
 
     class Health(object):
         # TODO: All of the health endpoints support all consistency modes
@@ -1499,7 +1669,8 @@ class Consul(object):
                     dc=None,
                     near=None,
                     token=None,
-                    node_meta=None):
+                    node_meta=None,
+                    timeout=None):
             """
             Returns a tuple of (*index*, *nodes*)
 
@@ -1527,6 +1698,11 @@ class Consul(object):
 
             *node_meta* is an optional meta data used for filtering, a
             dictionary formatted as {k1:v1, k2:v2}.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
             """
             params = []
             if index:
@@ -1552,7 +1728,7 @@ class Consul(object):
             return self.agent.http.get(
                 CB.json(index=True),
                 '/v1/health/service/%s' % service,
-                params=params)
+                params=params, timeout=timeout)
 
         def checks(
                 self,
@@ -1562,7 +1738,8 @@ class Consul(object):
                 dc=None,
                 near=None,
                 token=None,
-                node_meta=None):
+                node_meta=None,
+                timeout=None):
             """
             Returns a tuple of (*index*, *checks*) with *checks* being the
             checks associated with the service.
@@ -1586,6 +1763,12 @@ class Consul(object):
 
             *node_meta* is an optional meta data used for filtering, a
             dictionary formatted as {k1:v1, k2:v2}.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
+
             """
             params = []
             if index:
@@ -1607,7 +1790,7 @@ class Consul(object):
             return self.agent.http.get(
                 CB.json(index=True),
                 '/v1/health/checks/%s' % service,
-                params=params)
+                params=params, timeout=timeout)
 
         def state(self,
                   name,
@@ -1616,7 +1799,8 @@ class Consul(object):
                   dc=None,
                   near=None,
                   token=None,
-                  node_meta=None):
+                  node_meta=None,
+                  timeout=None):
             """
             Returns a tuple of (*index*, *nodes*)
 
@@ -1645,6 +1829,11 @@ class Consul(object):
             dictionary formatted as {k1:v1, k2:v2}.
 
             *nodes* are the nodes providing the given service.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
             """
             assert name in ['any', 'unknown', 'passing', 'warning', 'critical']
             params = []
@@ -1667,9 +1856,15 @@ class Consul(object):
             return self.agent.http.get(
                 CB.json(index=True),
                 '/v1/health/state/%s' % name,
-                params=params)
+                params=params, timeout=timeout)
 
-        def node(self, node, index=None, wait=None, dc=None, token=None):
+        def node(self, 
+                 node, 
+                 index=None, 
+                 wait=None, 
+                 dc=None, 
+                 token=None,
+                 timeout=None):
             """
             Returns a tuple of (*index*, *checks*)
 
@@ -1686,6 +1881,11 @@ class Consul(object):
             *token* is an optional `ACL token`_ to apply to this request.
 
             *nodes* are the nodes providing the given service.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
             """
             params = []
             if index:
@@ -1702,7 +1902,7 @@ class Consul(object):
             return self.agent.http.get(
                 CB.json(index=True),
                 '/v1/health/node/%s' % node,
-                params=params)
+                params=params, timeout=timeout)
 
     class Session(object):
         def __init__(self, agent):
@@ -1716,7 +1916,8 @@ class Consul(object):
                 lock_delay=15,
                 behavior='release',
                 ttl=None,
-                dc=None):
+                dc=None,
+                timeout=None):
             """
             Creates a new session. There is more documentation for sessions
             `here <https://consul.io/docs/internals/sessions.html>`_.
@@ -1746,6 +1947,11 @@ class Consul(object):
 
             By default the session will be created in the current datacenter
             but an optional *dc* can be provided.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             Returns the string *session_id* for the session.
             """
@@ -1778,11 +1984,17 @@ class Consul(object):
                 CB.json(is_id=True),
                 '/v1/session/create',
                 params=params,
-                data=data)
+                data=data,
+                timeout=timeout)
 
-        def destroy(self, session_id, dc=None):
+        def destroy(self, session_id, dc=None, timeout=None):
             """
             Destroys the session *session_id*
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             Returns *True* on success.
             """
@@ -1793,9 +2005,15 @@ class Consul(object):
             return self.agent.http.put(
                 CB.bool(),
                 '/v1/session/destroy/%s' % session_id,
-                params=params)
+                params=params, timeout=timeout)
 
-        def list(self, index=None, wait=None, consistency=None, dc=None):
+        def list(
+                self,
+                index=None,
+                wait=None,
+                consistency=None,
+                dc=None,
+                timeout=None):
             """
             Returns a tuple of (*index*, *sessions*) of all active sessions in
             the *dc* datacenter. *dc* defaults to the current datacenter of
@@ -1811,6 +2029,11 @@ class Consul(object):
             *consistency* can be either 'default', 'consistent' or 'stale'. if
             not specified *consistency* will the consistency level this client
             was configured with.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             The response looks like this::
 
@@ -1839,9 +2062,19 @@ class Consul(object):
             if consistency in ('consistent', 'stale'):
                 params.append((consistency, '1'))
             return self.agent.http.get(
-                CB.json(index=True), '/v1/session/list', params=params)
+                CB.json(index=True), 
+                '/v1/session/list', 
+                params=params,
+                timeout=timeout)
 
-        def node(self, node, index=None, wait=None, consistency=None, dc=None):
+        def node(
+                self,
+                node,
+                index=None,
+                wait=None,
+                consistency=None,
+                dc=None,
+                timeout=None):
             """
             Returns a tuple of (*index*, *sessions*) as per *session.list*, but
             filters the sessions returned to only those active for *node*.
@@ -1856,6 +2089,11 @@ class Consul(object):
             *consistency* can be either 'default', 'consistent' or 'stale'. if
             not specified *consistency* will the consistency level this client
             was configured with.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
             """
             params = []
             dc = dc or self.agent.dc
@@ -1870,14 +2108,15 @@ class Consul(object):
                 params.append((consistency, '1'))
             return self.agent.http.get(
                 CB.json(index=True),
-                '/v1/session/node/%s' % node, params=params)
+                '/v1/session/node/%s' % node, params=params, timeout=timeout)
 
         def info(self,
                  session_id,
                  index=None,
                  wait=None,
                  consistency=None,
-                 dc=None):
+                 dc=None,
+                 timeout=None):
             """
             Returns a tuple of (*index*, *session*) for the session
             *session_id* in the *dc* datacenter. *dc* defaults to the current
@@ -1893,6 +2132,11 @@ class Consul(object):
             *consistency* can be either 'default', 'consistent' or 'stale'. if
             not specified *consistency* will the consistency level this client
             was configured with.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
             """
             params = []
             dc = dc or self.agent.dc
@@ -1908,15 +2152,20 @@ class Consul(object):
             return self.agent.http.get(
                 CB.json(index=True, one=True),
                 '/v1/session/info/%s' % session_id,
-                params=params)
+                params=params, timeout=timeout)
 
-        def renew(self, session_id, dc=None):
+        def renew(self, session_id, dc=None, timeout=None):
             """
             This is used with sessions that have a TTL, and it extends the
             expiration by the TTL.
 
             *dc* is the optional datacenter that you wish to communicate with.
             If None is provided, defaults to the agent's datacenter.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             Returns the session.
             """
@@ -1927,43 +2176,57 @@ class Consul(object):
             return self.agent.http.put(
                 CB.json(one=True, allow_404=False),
                 '/v1/session/renew/%s' % session_id,
-                params=params)
+                params=params, timeout=timeout)
 
     class ACL(object):
         def __init__(self, agent):
             self.agent = agent
 
-        def list(self, token=None):
+        def list(self, token=None, timeout=None):
             """
             Lists all the active ACL tokens. This is a privileged endpoint, and
             requires a management token. *token* will override this client's
             default token.  An *ACLPermissionDenied* exception will be raised
             if a management token is not used.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
             """
             params = []
             token = token or self.agent.token
             if token:
                 params.append(('token', token))
             return self.agent.http.get(
-                CB.json(), '/v1/acl/list', params=params)
+                CB.json(), '/v1/acl/list', params=params, timeout=timeout)
 
-        def info(self, acl_id, token=None):
+        def info(self, acl_id, token=None, timeout=None):
             """
             Returns the token information for *acl_id*.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
             """
             params = []
             token = token or self.agent.token
             if token:
                 params.append(('token', token))
             return self.agent.http.get(
-                CB.json(one=True), '/v1/acl/info/%s' % acl_id, params=params)
+                CB.json(one=True), 
+                '/v1/acl/info/%s' % acl_id, 
+                params=params,
+                timeout=timeout)
 
         def create(self,
                    name=None,
                    type='client',
                    rules=None,
                    acl_id=None,
-                   token=None):
+                   token=None,
+                   timeout=None):
             """
             Creates a new ACL token. This is a privileged endpoint, and
             requires a management token. *token* will override this client's
@@ -1993,6 +2256,11 @@ class Consul(object):
                   # Deny access to the private dir
                   policy = "deny"
                 }
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             Returns the string *acl_id* for the new token.
             """
@@ -2024,9 +2292,17 @@ class Consul(object):
                 CB.json(is_id=True),
                 '/v1/acl/create',
                 params=params,
-                data=data)
+                data=data,
+                timeout=timeout)
 
-        def update(self, acl_id, name=None, type=None, rules=None, token=None):
+        def update(
+                self,
+                acl_id,
+                name=None,
+                type=None,
+                rules=None,
+                token=None,
+                timeout=None):
             """
             Updates the ACL token *acl_id*. This is a privileged endpoint, and
             requires a management token. *token* will override this client's
@@ -2042,6 +2318,11 @@ class Consul(object):
 
             *rules* is an optional `HCL`_ string for this `ACL Token`_ Rule
             Specification.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             Returns the string *acl_id* of this token on success.
             """
@@ -2068,14 +2349,20 @@ class Consul(object):
                 CB.json(is_id=True),
                 '/v1/acl/update',
                 params=params,
-                data=data)
+                data=data, 
+                timeout=timeout)
 
-        def clone(self, acl_id, token=None):
+        def clone(self, acl_id, token=None, timeout=None):
             """
             Clones the ACL token *acl_id*. This is a privileged endpoint, and
             requires a management token. *token* will override this client's
             default token. An *ACLPermissionDenied* exception will be raised if
             a management token is not used.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             Returns the string of the newly created *acl_id*.
             """
@@ -2086,14 +2373,20 @@ class Consul(object):
             return self.agent.http.put(
                 CB.json(is_id=True),
                 '/v1/acl/clone/%s' % acl_id,
-                params=params)
+                params=params, 
+                timeout=timeout)
 
-        def destroy(self, acl_id, token=None):
+        def destroy(self, acl_id, token=None, timeout=None):
             """
             Destroys the ACL token *acl_id*. This is a privileged endpoint, and
             requires a management token. *token* will override this client's
             default token. An *ACLPermissionDenied* exception will be raised if
             a management token is not used.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
 
             Returns *True* on success.
             """
@@ -2104,7 +2397,8 @@ class Consul(object):
             return self.agent.http.put(
                 CB.json(),
                 '/v1/acl/destroy/%s' % acl_id,
-                params=params)
+                params=params,
+                timeout=timeout)
 
     class Status(object):
         """
@@ -2114,17 +2408,30 @@ class Consul(object):
         def __init__(self, agent):
             self.agent = agent
 
-        def leader(self):
+        def leader(self, timeout=None):
             """
             This endpoint is used to get the Raft leader for the datacenter
             in which the agent is running.
-            """
-            return self.agent.http.get(CB.json(), '/v1/status/leader')
 
-        def peers(self):
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
+            """
+            return self.agent.http.get(
+                CB.json(), 
+                '/v1/status/leader', 
+                timeout=timeout)
+
+        def peers(self, timeout=None):
             """
             This endpoint retrieves the Raft peers for the datacenter in which
             the the agent is running.
+
+            *timeout* is the optional timeout for HTTP requests made to Consul.
+            If None is provided, defaults to timeout value set when
+            instantiating consul instance, or the default value set in
+            requests.
             """
             return self.agent.http.get(CB.json(), '/v1/status/peers')
 
@@ -2388,14 +2695,22 @@ class Consul(object):
         def __init__(self, agent):
             self.agent = agent
 
-        def datacenters(self):
+        def datacenters(self, timeout=None):
             """
             Returns the WAN network coordinates for all Consul servers,
             organized by DCs.
             """
-            return self.agent.http.get(CB.json(), '/v1/coordinate/datacenters')
+            return self.agent.http.get(
+                CB.json(),
+                '/v1/coordinate/datacenters',
+                timeout=timeout)
 
-        def nodes(self, dc=None, index=None, wait=None, consistency=None):
+        def nodes(self, 
+                  dc=None, 
+                  index=None, 
+                  wait=None, 
+                  consistency=None, 
+                  timeout=None):
             """
             *dc* is the datacenter that this agent will communicate with. By
             default the datacenter of the host is used.
@@ -2422,15 +2737,15 @@ class Consul(object):
             if consistency in ('consistent', 'stale'):
                 params.append((consistency, '1'))
             return self.agent.http.get(
-                CB.json(index=True), '/v1/coordinate/nodes', params=params)
+                CB.json(index=True), '/v1/coordinate/nodes', params=params, timeout=timeout)
 
     class Operator(object):
         def __init__(self, agent):
             self.agent = agent
 
-        def raft_config(self):
+        def raft_config(self, timeout=None):
             """
             Returns raft configuration.
             """
             return self.agent.http.get(
-                CB.json(), '/v1/operator/raft/configuration')
+                CB.json(), '/v1/operator/raft/configuration', timeout=timeout)

--- a/consul/std.py
+++ b/consul/std.py
@@ -16,29 +16,38 @@ class HTTPClient(base.HTTPClient):
         return base.Response(
             response.status_code, response.headers, response.text)
 
-    def get(self, callback, path, params=None):
+    def get(self, callback, path, params=None, timeout=None):
         uri = self.uri(path, params)
+        # TODO: Work out behaviour when timeout is 0 (i.e. disable timeout)
+        timeout = timeout if timeout else self.timeout
         return callback(self.response(
-            self.session.get(uri, verify=self.verify, cert=self.cert)))
+            self.session.get(uri, verify=self.verify, cert=self.cert, timeout=timeout)))
 
-    def put(self, callback, path, params=None, data=''):
+    def put(self, callback, path, params=None, data='', timeout=None):
         uri = self.uri(path, params)
+        # TODO: Work out behaviour when timeout is 0 (i.e. disable timeout)
+        timeout = timeout if timeout else self.timeout
         return callback(self.response(
             self.session.put(uri, data=data, verify=self.verify,
-                             cert=self.cert)))
+                             cert=self.cert, timeout=timeout)))
 
-    def delete(self, callback, path, params=None):
+    def delete(self, callback, path, params=None, timeout=None):
         uri = self.uri(path, params)
+        # TODO: Work out behaviour when timeout is 0 (i.e. disable timeout)
+        timeout = timeout if timeout else self.timeout
         return callback(self.response(
-            self.session.delete(uri, verify=self.verify, cert=self.cert)))
+            self.session.delete(uri, verify=self.verify, cert=self.cert,
+                                timeout=timeout)))
 
-    def post(self, callback, path, params=None, data=''):
+    def post(self, callback, path, params=None, data='', timeout=None):
         uri = self.uri(path, params)
+        # TODO: Work out behaviour when timeout is 0 (i.e. disable timeout)
+        timeout = timeout if timeout else self.timeout
         return callback(self.response(
             self.session.post(uri, data=data, verify=self.verify,
-                              cert=self.cert)))
+                              cert=self.cert, timeout=timeout)))
 
 
 class Consul(base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, verify, cert)
+    def connect(self, host, port, scheme, verify=True, cert=None, timeout=None):
+        return HTTPClient(host, port, scheme, verify, cert, timeout)

--- a/consul/tornado.py
+++ b/consul/tornado.py
@@ -53,5 +53,5 @@ class HTTPClient(base.HTTPClient):
 
 
 class Consul(base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, verify=verify, cert=cert)
+    def connect(self, host, port, scheme, verify=True, cert=None, timeout=None):
+        return HTTPClient(host, port, scheme, verify=verify, cert=cert, timeout=None)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,27 +10,27 @@ CB = consul.base.CB
 Response = consul.base.Response
 
 Request = collections.namedtuple(
-    'Request', ['method', 'path', 'params', 'data'])
+    'Request', ['method', 'path', 'params', 'data', 'timeout'])
 
 
 class HTTPClient(object):
     def __init__(self, host=None, port=None, scheme=None,
-                 verify=True, cert=None):
+                 verify=True, cert=None, timeout=None):
         pass
 
-    def get(self, callback, path, params=None):
-        return Request('get', path, params, None)
+    def get(self, callback, path, params=None, timeout=None):
+        return Request('get', path, params, None, timeout)
 
-    def put(self, callback, path, params=None, data=''):
-        return Request('put', path, params, data)
+    def put(self, callback, path, params=None, data='', timeout=None):
+        return Request('put', path, params, data, timeout)
 
-    def delete(self, callback, path, params=None):
-        return Request('delete', path, params, None)
+    def delete(self, callback, path, params=None, timeout=None):
+        return Request('delete', path, params, None, timeout)
 
 
 class Consul(consul.base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, verify=verify, cert=None)
+    def connect(self, host, port, scheme, verify=True, cert=None, timeout=None):
+        return HTTPClient(host, port, scheme, verify=verify, cert=None, timeout=timeout)
 
 
 def _should_support(c):


### PR DESCRIPTION
As discussed in #45, this adds both a global `consul.Consul(timeout=...)` option, and request specific timeout option (e.g. `c.kv.get('foo',timeout=...)`). This will be applied as both a connect timeout and read timeout to each adapter, so requests could take up to twice this value to time out if they take a long time to connect _and_ read.

Passes the existing tests on my local machine but I don't currently have access to a python 3.4 system or pypy system to test with.

Tests for the timeout options themselves may be a bit sparse and could do with some work, and the test for 'connect timeout' relies on setting a nonzero but tiny timeout to trigger before even a local connect is possible. Could fail randomly but not sure of a better way to test connection timeout at this point.

Thoughts? Improvements? Anything obvious I've missed?
