### PR TITLE
force to use UTF-8 encoding for the response

### DIFF
--- a/consul/std.py
+++ b/consul/std.py
@@ -19,6 +19,7 @@ class HTTPClient(object):
         self.session = requests.session()
 
     def response(self, response):
+        response.encoding = 'utf-8'
         return base.Response(
             response.status_code, response.headers, response.text)
 


### PR DESCRIPTION
Any operations with large response.text without set encoding generate high CPU load