### PR TITLE
tests: handle multiple private interfaces

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,9 +64,10 @@ def start_consul_instance(acl_master_token=None):
     else:
         postfix = 'linux64'
     bin = os.path.join(os.path.dirname(__file__), 'consul.'+postfix)
-    command = """
-        {bin} agent -server -bootstrap -config-dir=. -data-dir=./data
-    """.format(bin=bin).strip()
+    command = '{bin} agent -server -bootstrap' \
+              ' -bind=127.0.0.1' \
+              ' -config-dir=. -data-dir=./data'
+    command = command.format(bin=bin).strip()
     command = shlex.split(command)
 
     p = subprocess.Popen(


### PR DESCRIPTION
This fix handles the case where multiple private interfaces exists on the developer machine. Currently, attempting to start the server will faile silently. This fix forces the use of the loopback interface.