### PR TITLE
Add timeout constructor parameter for use in HTTPClient operations

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -1,11 +1,9 @@
-import collections
-import logging
 import base64
+import collections
 import json
+import logging
 import os
-
 import six
-
 
 log = logging.getLogger(__name__)
 
@@ -171,7 +169,8 @@ class Consul(object):
             scheme='http',
             consistency='default',
             dc=None,
-            verify=True):
+            verify=True,
+            timeout=None):
         """
         *token* is an optional `ACL token`_. If supplied it will be used by
         default for all requests made with this client session. It's still
@@ -199,7 +198,7 @@ class Consul(object):
         if os.getenv('CONSUL_HTTP_SSL_VERIFY') is not None:
             verify = os.getenv('CONSUL_HTTP_SSL_VERIFY') == 'true'
 
-        self.http = self.connect(host, port, scheme, verify)
+        self.http = self.connect(host, port, scheme, verify, timeout=timeout)
         self.token = os.getenv('CONSUL_HTTP_TOKEN', token)
         self.scheme = scheme
         self.dc = dc

--- a/consul/std.py
+++ b/consul/std.py
@@ -1,6 +1,6 @@
-from six.moves import urllib
-
 import requests
+
+from six.moves import urllib
 
 from consul import base
 
@@ -10,11 +10,12 @@ __all__ = ['Consul']
 
 class HTTPClient(object):
     def __init__(self, host='127.0.0.1', port=8500, scheme='http',
-                 verify=True):
+                 verify=True, timeout=None):
         self.host = host
         self.port = port
         self.scheme = scheme
         self.verify = verify
+        self.timeout = timeout
         self.base_uri = '%s://%s:%s' % (self.scheme, self.host, self.port)
         self.session = requests.session()
 
@@ -32,19 +33,22 @@ class HTTPClient(object):
     def get(self, callback, path, params=None):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.get(uri, verify=self.verify)))
+            self.session.get(uri, verify=self.verify,
+                             timeout=self.timeout)))
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.put(uri, data=data, verify=self.verify)))
+            self.session.put(uri, data=data, verify=self.verify,
+                             timeout=self.timeout)))
 
     def delete(self, callback, path, params=None):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.delete(uri, verify=self.verify)))
+            self.session.delete(uri, verify=self.verify,
+                                timeout=self.timeout)))
 
 
 class Consul(base.Consul):
-    def connect(self, host, port, scheme, verify=True):
-        return HTTPClient(host, port, scheme, verify)
+    def connect(self, host, port, scheme, verify=True, timeout=None):
+        return HTTPClient(host, port, scheme, verify, timeout=timeout)


### PR DESCRIPTION
Hi,

We would like to use this module in django project (for filling settings on startup), yet we cannot afford any delay on boot, so I added support for requests' timeout parameter. Would you like to merge it?

Sample usage:

start test server that will timeout when client connects:

```
nc -lp 8501
```

run code that will throw timeout after 5 seconds:

```
import consul
import requests

try:
   consl = consul.Consul(host='localhost', port=8501, timeout=5)
   index, values = consl.kv.get('key', recurse=True)
except requests.Timeout:
   print 'timeout occurred'
```