### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Installation
 .. |Coverage Status|
    image:: https://img.shields.io/coveralls/cablehead/python-consul.svg?style=flat-square
    :target: https://coveralls.io/r/cablehead/python-consul?branch=master
-.. _Read the Docs: http://python-consul.readthedocs.org/
+.. _Read the Docs: https://python-consul.readthedocs.io/
 
 Status
 ------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -250,7 +250,7 @@ Consul.acl
 .. _Vanilla: https://github.com/cablehead/vanilla
 .. _gevent: http://www.gevent.org
 .. _Tornado: http://www.tornadoweb.org
-.. _gen.coroutine: http://tornado.readthedocs.org/en/latest/gen.html
+.. _gen.coroutine: https://tornado.readthedocs.io/en/latest/gen.html
 .. _asyncio.coroutine: https://docs.python.org/3/library/asyncio-task.html#coroutines
 .. _aiohttp: https://github.com/KeepSafe/aiohttp
 .. _asyncio: https://docs.python.org/3/library/asyncio.html


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.