### PR TITLE
Tornado backend encoding bug

### DIFF
--- a/consul/tornado.py
+++ b/consul/tornado.py
@@ -47,7 +47,7 @@ class HTTPClient(object):
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
-        request = httpclient.HTTPRequest(uri, method='PUT', body=data,
+        request = httpclient.HTTPRequest(uri, method='PUT', body='' if data is None else data,
                                          validate_cert=self.verify)
         return self._request(callback, request)
 

--- a/consul/tornado.py
+++ b/consul/tornado.py
@@ -47,7 +47,8 @@ class HTTPClient(object):
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
-        request = httpclient.HTTPRequest(uri, method='PUT', body='' if data is None else data,
+        request = httpclient.HTTPRequest(uri, method='PUT',
+                                         body='' if data is None else data,
                                          validate_cert=self.verify)
         return self._request(callback, request)
 

--- a/tests/test_std.py
+++ b/tests/test_std.py
@@ -52,7 +52,7 @@ class TestConsul(object):
         # test empty-string comes back as `None`
         c.kv.put('foo', '')
         index, data = c.kv.get('foo')
-        assert data['Value'] == None
+        assert data['Value'] is None
 
         # test None
         c.kv.put('foo', None)

--- a/tests/test_std.py
+++ b/tests/test_std.py
@@ -49,6 +49,11 @@ class TestConsul(object):
         index, data = c.kv.get('foo')
         assert data['Value'] == six.b('bar')
 
+        # test empty-string comes back as `None`
+        c.kv.put('foo', '')
+        index, data = c.kv.get('foo')
+        assert data['Value'] == None
+
         # test None
         c.kv.put('foo', None)
         index, data = c.kv.get('foo')

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -143,6 +143,12 @@ class TestConsul(object):
             index, data = yield c.kv.get('foo')
             assert data['Value'] == six.b('bar')
 
+            # test empty-string comes back as `None`
+            response = yield c.kv.put('foo', '')
+            assert response is True
+            index, data = yield c.kv.get('foo')
+            assert data['Value'] == None
+
             # test None
             response = yield c.kv.put('foo', None)
             assert response is True

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -126,6 +126,39 @@ class TestConsul(object):
         loop.add_timeout(time.time()+(1.0/100), put)
         loop.run_sync(get)
 
+    def test_kv_encoding(self, loop, consul_port):
+        @gen.coroutine
+        def main():
+            c = consul.tornado.Consul(port=consul_port)
+
+            # test binary
+            response = yield c.kv.put('foo', struct.pack('i', 1000))
+            assert response is True
+            index, data = yield c.kv.get('foo')
+            assert struct.unpack('i', data['Value']) == (1000,)
+
+            # test unicode
+            response = yield c.kv.put('foo', u'bar')
+            assert response is True
+            index, data = yield c.kv.get('foo')
+            assert data['Value'] == six.b('bar')
+
+            # test None
+            response = yield c.kv.put('foo', None)
+            assert response is True
+            index, data = yield c.kv.get('foo')
+            assert data['Value'] is None
+
+            # check unencoded values raises assert
+            try:
+                yield c.kv.put('foo', {1: 2})
+            except AssertionError as e:
+                raised = True
+            assert raised
+
+            loop.stop()
+        loop.run_sync(main)
+
     def test_agent_services(self, loop, consul_port):
         @gen.coroutine
         def main():

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -147,7 +147,7 @@ class TestConsul(object):
             response = yield c.kv.put('foo', '')
             assert response is True
             index, data = yield c.kv.get('foo')
-            assert data['Value'] == None
+            assert data['Value'] is None
 
             # test None
             response = yield c.kv.put('foo', None)
@@ -158,7 +158,7 @@ class TestConsul(object):
             # check unencoded values raises assert
             try:
                 yield c.kv.put('foo', {1: 2})
-            except AssertionError as e:
+            except AssertionError:
                 raised = True
             assert raised
 


### PR DESCRIPTION
The `Consul.KV.put` docs state:

> _value_ can either be None (useful for marking a key as a
> directory) or any string type, including binary data (e.g. a
> msgpack'd data structure)

However, giving `None` as a value to the `consul.tornado` backend causes:

`ValueError: Body must not be None for method PUT (unless allow_nonstandard_methods is true)`

In this change the bug is corrected and tests are added, in three commits:
1. 2603ef3 exposes the error by copying the "encoding" tests from std to tornado.
2. 853e774 corrects the error by exploiting the existing treatment of empty string.
3. a4aee7c adds an additional test to std and tornado to explicitly show the treatment of empty string.
