### PR TITLE
HttpClient base class and url quoting

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -1,3 +1,4 @@
+import abc
 import collections
 import logging
 import base64
@@ -5,6 +6,7 @@ import json
 import os
 
 import six
+from six.moves import urllib
 
 
 log = logging.getLogger(__name__)
@@ -220,6 +222,39 @@ class CB(object):
                 return response.headers['X-Consul-Index'], data
             return data
         return cb
+
+
+class HTTPClient(six.with_metaclass(abc.ABCMeta, object)):
+    def __init__(self, host='127.0.0.1', port=8500, scheme='http',
+                 verify=True, cert=None):
+        self.host = host
+        self.port = port
+        self.scheme = scheme
+        self.verify = verify
+        self.base_uri = '%s://%s:%s' % (self.scheme, self.host, self.port)
+        self.cert = cert
+
+    def uri(self, path, params=None):
+        uri = self.base_uri + path
+        if not params:
+            return uri
+        return '%s?%s' % (uri, urllib.parse.urlencode(params))
+
+    @abc.abstractmethod
+    def get(self, callback, path, params=None):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def put(self, callback, path, params=None, data=''):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def delete(self, callback, path, params=None):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def post(self, callback, path, params=None, data=''):
+        raise NotImplementedError
 
 
 class Consul(object):

--- a/consul/base.py
+++ b/consul/base.py
@@ -235,10 +235,10 @@ class HTTPClient(six.with_metaclass(abc.ABCMeta, object)):
         self.cert = cert
 
     def uri(self, path, params=None):
-        uri = self.base_uri + path
-        if not params:
-            return uri
-        return '%s?%s' % (uri, urllib.parse.urlencode(params))
+        uri = urllib.parse.quote(self.base_uri + path, safe='/:')
+        if params:
+            uri = '%s?%s' % (uri, urllib.parse.urlencode(params))
+        return uri
 
     @abc.abstractmethod
     def get(self, callback, path, params=None):

--- a/consul/std.py
+++ b/consul/std.py
@@ -1,5 +1,3 @@
-from six.moves import urllib
-
 import requests
 
 from consul import base
@@ -8,27 +6,15 @@ from consul import base
 __all__ = ['Consul']
 
 
-class HTTPClient(object):
-    def __init__(self, host='127.0.0.1', port=8500, scheme='http',
-                 verify=True, cert=None):
-        self.host = host
-        self.port = port
-        self.scheme = scheme
-        self.verify = verify
-        self.base_uri = '%s://%s:%s' % (self.scheme, self.host, self.port)
-        self.cert = cert
+class HTTPClient(base.HTTPClient):
+    def __init__(self, *args, **kwargs):
+        super(HTTPClient, self).__init__(*args, **kwargs)
         self.session = requests.session()
 
     def response(self, response):
         response.encoding = 'utf-8'
         return base.Response(
             response.status_code, response.headers, response.text)
-
-    def uri(self, path, params=None):
-        uri = self.base_uri + path
-        if not params:
-            return uri
-        return '%s?%s' % (uri, urllib.parse.urlencode(params))
 
     def get(self, callback, path, params=None):
         uri = self.uri(path, params)

--- a/consul/tornado.py
+++ b/consul/tornado.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from six.moves import urllib
-
 from tornado import httpclient
 from tornado import gen
 
@@ -11,21 +9,10 @@ from consul import base
 __all__ = ['Consul']
 
 
-class HTTPClient(object):
-    def __init__(self, host='127.0.0.1', port=8500, scheme='http',
-                 verify=True, cert=None):
-        self.host = host
-        self.port = port
-        self.scheme = scheme
-        self.verify = verify
-        self.base_uri = '%s://%s:%s' % (self.scheme, self.host, self.port)
+class HTTPClient(base.HTTPClient):
+    def __init__(self, *args, **kwargs):
+        super(HTTPClient, self).__init__(*args, **kwargs)
         self.client = httpclient.AsyncHTTPClient()
-
-    def uri(self, path, params=None):
-        uri = self.base_uri + path
-        if not params:
-            return uri
-        return '%s?%s' % (uri, urllib.parse.urlencode(params))
 
     def response(self, response):
         return base.Response(


### PR DESCRIPTION
I have created a base abstract class for HttpClient implementations. As this allows us to enforce interfaces and also write common functionality (think uri method) once.

Based on the above work, I have also added a fix for #156 to quote uri and added a test case for the issue.