### PR TITLE
add txn support to python client

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -317,6 +317,7 @@ class Consul(object):
 
         self.event = Consul.Event(self)
         self.kv = Consul.KV(self)
+        self.txn = Consul.Txn(self)
         self.agent = Consul.Agent(self)
         self.catalog = Consul.Catalog(self)
         self.health = Consul.Health(self)
@@ -639,6 +640,30 @@ class Consul(object):
 
             return self.agent.http.delete(
                 CB.json(), '/v1/kv/%s' % key, params=params)
+
+    class Txn(object):
+        """
+        The /txn endpoints manage updates or fetches of multiple keys inside
+        a single, atomic transaction.
+        """
+        def __init__(self, agent):
+            self.agent = agent
+
+        def put(self, value):
+            """
+            value is a list of operations
+            Each *operation* looks like this::
+
+                {
+                    "KV": {
+                        "Verb": "set",
+                        "Key": "foo",
+                        "Value": "YmFy" # base64-encoded blob of data
+                    }
+                }
+            """
+            return self.agent.http.put(CB.json(), "/v1/txn",
+                                       data=json.dumps(value))
 
     class Agent(object):
         """

--- a/consul/base.py
+++ b/consul/base.py
@@ -230,6 +230,7 @@ class CB(object):
 
 
 class HTTPClient(six.with_metaclass(abc.ABCMeta, object)):
+
     def __init__(self, host='127.0.0.1', port=8500, scheme='http',
                  verify=True, cert=None):
         self.host = host

--- a/tests/test_std.py
+++ b/tests/test_std.py
@@ -1,3 +1,4 @@
+import base64
 import operator
 import struct
 import time
@@ -21,6 +22,18 @@ class TestHTTPClient(object):
 
 
 class TestConsul(object):
+
+    def test_transaction(self, consul_port):
+        c = consul.Consul(port=consul_port)
+        value = base64.b64encode(b"1").decode("utf8")
+        d = {"KV": {"Verb": "set", "Key": "asdf", "Value": value}}
+        r = c.txn.put([d])
+        assert r["Errors"] is None
+
+        d = {"KV": {"Verb": "get", "Key": "asdf"}}
+        r = c.txn.put([d])
+        assert r["Results"][0]["KV"]["Value"] == value
+
     def test_kv(self, consul_port):
         c = consul.Consul(port=consul_port)
         index, data = c.kv.get('foo')

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -1,3 +1,4 @@
+import base64
 import struct
 import time
 
@@ -29,6 +30,22 @@ def sleep(loop, s):
 
 
 class TestConsul(object):
+
+    def test_transaction(self, loop, consul_port):
+        @gen.coroutine
+        def main():
+            c = consul.tornado.Consul(port=consul_port)
+            value = base64.b64encode(b"1").decode("utf8")
+            d = {"KV": {"Verb": "set", "Key": "asdf", "Value": value}}
+            r = yield c.txn.put([d])
+            assert r["Errors"] is None
+
+            d = {"KV": {"Verb": "get", "Key": "asdf"}}
+            r = yield c.txn.put([d])
+            assert r["Results"][0]["KV"]["Value"] == value
+            loop.stop()
+        loop.run_sync(main)
+
     def test_kv(self, loop, consul_port):
         @gen.coroutine
         def main():

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -1,3 +1,4 @@
+import base64
 import struct
 
 import pytest
@@ -23,6 +24,19 @@ def sleep(seconds):
 
 
 class TestConsul(object):
+
+    @pytest.inlineCallbacks
+    def test_transaction(self, consul_port):
+        c = consul.twisted.Consul(port=consul_port)
+        value = base64.b64encode(b"1").decode("utf8")
+        d = {"KV": {"Verb": "set", "Key": "asdf", "Value": value}}
+        r = yield c.txn.put([d])
+        assert r["Errors"] is None
+
+        d = {"KV": {"Verb": "get", "Key": "asdf"}}
+        r = yield c.txn.put([d])
+        assert r["Results"][0]["KV"]["Value"] == value
+
     @pytest.inlineCallbacks
     def test_kv(self, consul_port):
         c = consul.twisted.Consul(port=consul_port)


### PR DESCRIPTION
Related issue: https://github.com/cablehead/python-consul/issues/148

1. Applications still need to prepare the operations including decoding/encoding value into `base64` encoded blob of data.

2. Applications also need to convert the value from `base64` to normal strings. 

Thanks for the reviewing.

cc @beardedeagle