### PR TITLE
Fix deregister service and add tests

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -886,7 +886,7 @@ class Consul(object):
                 take care of deregistering the service with the Catalog. If
                 there is an associated check, that is also deregistered.
                 """
-                return self.agent.http.get(
+                return self.agent.http.put(
                     CB.bool(), '/v1/agent/service/deregister/%s' % service_id)
 
             def maintenance(self, service_id, enable, reason=None):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -175,3 +175,39 @@ class TestChecks(object):
     def test_ttl_check(self):
         ch = consul.base.Check.ttl('1m')
         assert ch == {'ttl': '1m'}
+
+
+@pytest.fixture()
+def consul_client():
+    return Consul()
+
+
+class TestAgentService(object):
+    def test_list(self, consul_client):
+        ch = consul_client.agent.services()
+        assert ch == Request(method='get', path='/v1/agent/services',
+                             params=None, data=None)
+
+    def test_register(self, consul_client):
+        ch = consul_client.agent.service.register('test_service')
+        assert ch == Request(method='put', params={},
+                             path='/v1/agent/service/register',
+                             data='{"name": "test_service"}')
+
+    def test_deregister(self, consul_client):
+        ch = consul_client.agent.service.deregister('testservice')
+        assert ch == Request(method='put',
+                             path='/v1/agent/service/deregister/testservice',
+                             params=None, data='')
+
+    def test_mm_enable(self, consul_client):
+        ch = consul_client.agent.service.maintenance('testservice', True)
+        assert ch == Request(method='put',
+                             path='/v1/agent/service/maintenance/testservice',
+                             params={"enable": True}, data='')
+
+    def test_mm_disable(self, consul_client):
+        ch = consul_client.agent.service.maintenance('testservice', False)
+        assert ch == Request(method='put',
+                             path='/v1/agent/service/maintenance/testservice',
+                             params={"enable": False}, data='')


### PR DESCRIPTION
Service deregister needs to be PUT instead of GET.

Also added tests for the Service object, using the API definition as comparisons.