### PR TITLE
Specify timeout for http requests

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -231,13 +231,14 @@ class CB(object):
 
 class HTTPClient(six.with_metaclass(abc.ABCMeta, object)):
     def __init__(self, host='127.0.0.1', port=8500, scheme='http',
-                 verify=True, cert=None):
+                 verify=True, cert=None, timeout=None):
         self.host = host
         self.port = port
         self.scheme = scheme
         self.verify = verify
         self.base_uri = '%s://%s:%s' % (self.scheme, self.host, self.port)
         self.cert = cert
+        self.timeout = timeout
 
     def uri(self, path, params=None):
         uri = self.base_uri + urllib.parse.quote(path, safe='/:')

--- a/consul/std.py
+++ b/consul/std.py
@@ -18,22 +18,26 @@ class HTTPClient(base.HTTPClient):
 
     def get(self, callback, path, params=None):
         uri = self.uri(path, params)
+        params.timeout = self.timeout
         return callback(self.response(
             self.session.get(uri, verify=self.verify, cert=self.cert)))
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
+        params.timeout = self.timeout
         return callback(self.response(
             self.session.put(uri, data=data, verify=self.verify,
                              cert=self.cert)))
 
     def delete(self, callback, path, params=None):
         uri = self.uri(path, params)
+        params.timeout = self.timeout
         return callback(self.response(
             self.session.delete(uri, verify=self.verify, cert=self.cert)))
 
     def post(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
+        params.timeout = self.timeout
         return callback(self.response(
             self.session.post(uri, data=data, verify=self.verify,
                               cert=self.cert)))

--- a/consul/std.py
+++ b/consul/std.py
@@ -40,5 +40,5 @@ class HTTPClient(base.HTTPClient):
 
 
 class Consul(base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, verify, cert)
+    def connect(self, host, port, scheme, verify=True, cert=None, timeout=None):
+        return HTTPClient(host, port, scheme, verify, cert, timeout)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -11,7 +11,7 @@ Request = collections.namedtuple(
 
 class HTTPClient(object):
     def __init__(self, host=None, port=None, scheme=None,
-                 verify=True, cert=None):
+                 verify=True, cert=None, timeout=None):
         pass
 
     def get(self, callback, path, params=None):
@@ -25,8 +25,8 @@ class HTTPClient(object):
 
 
 class Consul(consul.base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, verify=verify, cert=None)
+    def connect(self, host, port, scheme, verify=True, cert=None, timeout=None):
+        return HTTPClient(host, port, scheme, verify=verify, cert=None, timeout=None)
 
 
 def _should_support(c):


### PR DESCRIPTION
Issue https://github.com/cablehead/python-consul/issues/45

Relevant use-cases
* [x] set optional timeout when creating consul object
* [ ] set optional timeout via acl
* [ ] set optional timeout for each method doing http requests