### PR TITLE
Specify timeout for http requests

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -231,13 +231,14 @@ class CB(object):
 
 class HTTPClient(six.with_metaclass(abc.ABCMeta, object)):
     def __init__(self, host='127.0.0.1', port=8500, scheme='http',
-                 verify=True, cert=None):
+                 verify=True, cert=None, timeout=None):
         self.host = host
         self.port = port
         self.scheme = scheme
         self.verify = verify
         self.base_uri = '%s://%s:%s' % (self.scheme, self.host, self.port)
         self.cert = cert
+        self.timeout = timeout
 
     def uri(self, path, params=None):
         uri = self.base_uri + urllib.parse.quote(path, safe='/:')

--- a/consul/std.py
+++ b/consul/std.py
@@ -18,22 +18,26 @@ class HTTPClient(base.HTTPClient):
 
     def get(self, callback, path, params=None):
         uri = self.uri(path, params)
+        params.timeout = self.timeout
         return callback(self.response(
             self.session.get(uri, verify=self.verify, cert=self.cert)))
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
+        params.timeout = self.timeout
         return callback(self.response(
             self.session.put(uri, data=data, verify=self.verify,
                              cert=self.cert)))
 
     def delete(self, callback, path, params=None):
         uri = self.uri(path, params)
+        params.timeout = self.timeout
         return callback(self.response(
             self.session.delete(uri, verify=self.verify, cert=self.cert)))
 
     def post(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
+        params.timeout = self.timeout
         return callback(self.response(
             self.session.post(uri, data=data, verify=self.verify,
                               cert=self.cert)))

--- a/consul/std.py
+++ b/consul/std.py
@@ -40,5 +40,5 @@ class HTTPClient(base.HTTPClient):
 
 
 class Consul(base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, verify, cert)
+    def connect(self, host, port, scheme, verify=True, cert=None, timeout=None):
+        return HTTPClient(host, port, scheme, verify, cert, timeout)

--- a/consul/std.py
+++ b/consul/std.py
@@ -20,7 +20,7 @@ class HTTPClient(base.HTTPClient):
         uri = self.uri(path, params)
         return callback(self.response(
             self.session.get(uri, verify=self.verify, cert=self.cert,
-            timeout=self.timeout)))
+                             timeout=self.timeout)))
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
@@ -32,7 +32,7 @@ class HTTPClient(base.HTTPClient):
         uri = self.uri(path, params)
         return callback(self.response(
             self.session.delete(uri, verify=self.verify, cert=self.cert,
-            timeout=self.timeout)))
+                                timeout=self.timeout)))
 
     def post(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
@@ -43,5 +43,5 @@ class HTTPClient(base.HTTPClient):
 
 class Consul(base.Consul):
     def connect(self, host, port, scheme, verify=True, cert=None,
-        timeout=None):
+                timeout=None):
         return HTTPClient(host, port, scheme, verify, cert, timeout)

--- a/consul/std.py
+++ b/consul/std.py
@@ -18,29 +18,25 @@ class HTTPClient(base.HTTPClient):
 
     def get(self, callback, path, params=None):
         uri = self.uri(path, params)
-        params.timeout = self.timeout
         return callback(self.response(
-            self.session.get(uri, verify=self.verify, cert=self.cert)))
+            self.session.get(uri, verify=self.verify, cert=self.cert, timeout=self.timeout)))
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
-        params.timeout = self.timeout
         return callback(self.response(
             self.session.put(uri, data=data, verify=self.verify,
-                             cert=self.cert)))
+                             cert=self.cert, timeout=self.timeout)))
 
     def delete(self, callback, path, params=None):
         uri = self.uri(path, params)
-        params.timeout = self.timeout
         return callback(self.response(
-            self.session.delete(uri, verify=self.verify, cert=self.cert)))
+            self.session.delete(uri, verify=self.verify, cert=self.cert, timeout=self.timeout)))
 
     def post(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
-        params.timeout = self.timeout
         return callback(self.response(
             self.session.post(uri, data=data, verify=self.verify,
-                              cert=self.cert)))
+                              cert=self.cert, timeout=self.timeout)))
 
 
 class Consul(base.Consul):

--- a/consul/std.py
+++ b/consul/std.py
@@ -19,7 +19,8 @@ class HTTPClient(base.HTTPClient):
     def get(self, callback, path, params=None):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.get(uri, verify=self.verify, cert=self.cert, timeout=self.timeout)))
+            self.session.get(uri, verify=self.verify, cert=self.cert,
+            timeout=self.timeout)))
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
@@ -30,7 +31,8 @@ class HTTPClient(base.HTTPClient):
     def delete(self, callback, path, params=None):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.delete(uri, verify=self.verify, cert=self.cert, timeout=self.timeout)))
+            self.session.delete(uri, verify=self.verify, cert=self.cert,
+            timeout=self.timeout)))
 
     def post(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
@@ -40,5 +42,6 @@ class HTTPClient(base.HTTPClient):
 
 
 class Consul(base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None, timeout=None):
+    def connect(self, host, port, scheme, verify=True, cert=None,
+        timeout=None):
         return HTTPClient(host, port, scheme, verify, cert, timeout)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -11,7 +11,7 @@ Request = collections.namedtuple(
 
 class HTTPClient(object):
     def __init__(self, host=None, port=None, scheme=None,
-                 verify=True, cert=None):
+                 verify=True, cert=None, timeout=None):
         pass
 
     def get(self, callback, path, params=None):
@@ -25,8 +25,8 @@ class HTTPClient(object):
 
 
 class Consul(consul.base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, verify=verify, cert=None)
+    def connect(self, host, port, scheme, verify=True, cert=None, timeout=None):
+        return HTTPClient(host, port, scheme, verify=verify, cert=None, timeout=None)
 
 
 def _should_support(c):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -25,8 +25,10 @@ class HTTPClient(object):
 
 
 class Consul(consul.base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None, timeout=None):
-        return HTTPClient(host, port, scheme, verify=verify, cert=None, timeout=None)
+    def connect(self, host, port, scheme, verify=True, cert=None,
+                timeout=None):
+        return HTTPClient(host, port, scheme, verify=verify, cert=None,
+                          timeout=None)
 
 
 def _should_support(c):


### PR DESCRIPTION
Issue https://github.com/cablehead/python-consul/issues/45
Make it possible to pass timeout to consul object or single methods, so the request will not block indefinetely.

Relevant use-cases:
* [x] set optional timeout when creating consul
* [ ] set optional timeout when calling methods doing http requests