### PR TITLE
Add token to http params for catalog deregister

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -1155,6 +1155,7 @@ class Consul(object):
             """
             assert not (service_id and check_id)
             data = {'node': node}
+            params = {}
             dc = dc or self.agent.dc
             if dc:
                 data['datacenter'] = dc
@@ -1165,8 +1166,11 @@ class Consul(object):
             token = token or self.agent.token
             if token:
                 data['WriteRequest'] = {'Token': token}
+                params['token'] = token
             return self.agent.http.put(
-                CB.bool(), '/v1/catalog/deregister', data=json.dumps(data))
+                CB.bool(), '/v1/catalog/deregister',
+                data=json.dumps(data),
+                params=params)
 
         def datacenters(self):
             """


### PR DESCRIPTION
Providing the token in the data does not work on Consul v1.0.3
This matches the implementation of the catalog register request