### PR TITLE
Correct agent/service/deregister call to be a PUT

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -886,7 +886,7 @@ class Consul(object):
                 take care of deregistering the service with the Catalog. If
                 there is an associated check, that is also deregistered.
                 """
-                return self.agent.http.get(
+                return self.agent.http.put(
                     CB.bool(), '/v1/agent/service/deregister/%s' % service_id)
 
             def maintenance(self, service_id, enable, reason=None):


### PR DESCRIPTION
According to https://www.consul.io/api/agent/service.html /v1/agent/service/deregister should be a PUT, not a GET operation.