### PR TITLE
Updated http endpoints for verbs that where enforced in version 1.0.0

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -772,7 +772,7 @@ class Consul(object):
             if wan:
                 params['wan'] = 1
 
-            return self.agent.http.get(
+            return self.agent.http.put(
                 CB.bool(), '/v1/agent/join/%s' % address, params=params)
 
         def force_leave(self, node):
@@ -787,7 +787,7 @@ class Consul(object):
             *node* is the node to change state for.
             """
 
-            return self.agent.http.get(
+            return self.agent.http.put(
                 CB.bool(), '/v1/agent/force-leave/%s' % node)
 
         class Service(object):
@@ -886,7 +886,7 @@ class Consul(object):
                 take care of deregistering the service with the Catalog. If
                 there is an associated check, that is also deregistered.
                 """
-                return self.agent.http.get(
+                return self.agent.http.put(
                     CB.bool(), '/v1/agent/service/deregister/%s' % service_id)
 
             def maintenance(self, service_id, enable, reason=None):
@@ -999,7 +999,7 @@ class Consul(object):
                 """
                 Remove a check from the local agent.
                 """
-                return self.agent.http.get(
+                return self.agent.http.put(
                     CB.bool(),
                     '/v1/agent/check/deregister/%s' % check_id)
 
@@ -1012,7 +1012,7 @@ class Consul(object):
                 if notes:
                     params['note'] = notes
 
-                return self.agent.http.get(
+                return self.agent.http.put(
                     CB.bool(),
                     '/v1/agent/check/pass/%s' % check_id,
                     params=params)
@@ -1027,7 +1027,7 @@ class Consul(object):
                 if notes:
                     params['note'] = notes
 
-                return self.agent.http.get(
+                return self.agent.http.put(
                     CB.bool(),
                     '/v1/agent/check/fail/%s' % check_id,
                     params=params)
@@ -1042,7 +1042,7 @@ class Consul(object):
                 if notes:
                     params['note'] = notes
 
-                return self.agent.http.get(
+                return self.agent.http.put(
                     CB.bool(),
                     '/v1/agent/check/warn/%s' % check_id,
                     params=params)


### PR DESCRIPTION
Per the Change log on consul for version [1.0.0](https://github.com/hashicorp/consul/blob/v1.0.0/CHANGELOG.md) I have updated the verbs per the following list:
 <details><summary>Detailed List of Updated Endpoints and Required HTTP Verbs</summary>

    | Endpoint | Required HTTP Verb |
    | -------- | ------------------ |
    | /v1/acl/info | GET |
    | /v1/acl/list | GET |
    | /v1/acl/replication | GET |
    | /v1/agent/check/deregister | PUT |
    | /v1/agent/check/fail | PUT |
    | /v1/agent/check/pass | PUT |
    | /v1/agent/check/register | PUT |
    | /v1/agent/check/warn | PUT |
    | /v1/agent/checks | GET |
    | /v1/agent/force-leave | PUT |
    | /v1/agent/join | PUT |
    | /v1/agent/members | GET |
    | /v1/agent/metrics | GET |
    | /v1/agent/self | GET |
    | /v1/agent/service/register | PUT |
    | /v1/agent/service/deregister | PUT |
    | /v1/agent/services | GET |
    | /v1/catalog/datacenters | GET |
    | /v1/catalog/deregister | PUT |
    | /v1/catalog/node | GET |
    | /v1/catalog/nodes | GET |
    | /v1/catalog/register | PUT |
    | /v1/catalog/service | GET |
    | /v1/catalog/services | GET |
    | /v1/coordinate/datacenters | GET |
    | /v1/coordinate/nodes | GET |
    | /v1/health/checks | GET |
    | /v1/health/node | GET |
    | /v1/health/service | GET |
    | /v1/health/state | GET |
    | /v1/internal/ui/node | GET |
    | /v1/internal/ui/nodes | GET |
    | /v1/internal/ui/services | GET |
    | /v1/session/info | GET |
    | /v1/session/list | GET |
    | /v1/session/node | GET |
    | /v1/status/leader | GET |
    | /v1/status/peers | GET |
    | /v1/operator/area/:uuid/members | GET |
    | /v1/operator/area/:uuid/join | PUT |

    </details>