### PR TITLE
put token to header if present

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -231,13 +231,14 @@ class CB(object):
 
 class HTTPClient(six.with_metaclass(abc.ABCMeta, object)):
     def __init__(self, host='127.0.0.1', port=8500, scheme='http',
-                 verify=True, cert=None):
+                 verify=True, cert=None, headers=None):
         self.host = host
         self.port = port
         self.scheme = scheme
         self.verify = verify
         self.base_uri = '%s://%s:%s' % (self.scheme, self.host, self.port)
         self.cert = cert
+        self.headers = headers or dict()
 
     def uri(self, path, params=None):
         uri = self.base_uri + urllib.parse.quote(path, safe='/:')
@@ -307,8 +308,8 @@ class Consul(object):
         if os.getenv('CONSUL_HTTP_SSL_VERIFY') is not None:
             verify = os.getenv('CONSUL_HTTP_SSL_VERIFY') == 'true'
 
-        self.http = self.connect(host, port, scheme, verify, cert)
         self.token = os.getenv('CONSUL_HTTP_TOKEN', token)
+        self.http = self.connect(host, port, scheme, verify, cert, self.token)
         self.scheme = scheme
         self.dc = dc
         assert consistency in ('default', 'consistent', 'stale'), \

--- a/consul/std.py
+++ b/consul/std.py
@@ -19,26 +19,29 @@ class HTTPClient(base.HTTPClient):
     def get(self, callback, path, params=None):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.get(uri, verify=self.verify, cert=self.cert)))
+            self.session.get(uri, verify=self.verify, cert=self.cert, headers=self.headers)))
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
         return callback(self.response(
             self.session.put(uri, data=data, verify=self.verify,
-                             cert=self.cert)))
+                             cert=self.cert, headers=self.headers)))
 
     def delete(self, callback, path, params=None):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.delete(uri, verify=self.verify, cert=self.cert)))
+            self.session.delete(uri, verify=self.verify, cert=self.cert, headers=self.headers)))
 
     def post(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
         return callback(self.response(
             self.session.post(uri, data=data, verify=self.verify,
-                              cert=self.cert)))
+                              cert=self.cert, headers=self.headers)))
 
 
 class Consul(base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, verify, cert)
+    def connect(self, host, port, scheme, verify=True, cert=None, token=None):
+        headers = dict()
+        if token is not None:
+            headers['X-Consul-Token'] = token
+        return HTTPClient(host, port, scheme, verify, cert, headers)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -25,8 +25,11 @@ class HTTPClient(object):
 
 
 class Consul(consul.base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, verify=verify, cert=None)
+    def connect(self, host, port, scheme, verify=True, cert=None, token=None):
+        headers = dict()
+        if token is not None:
+            headers['X-Consul-Token'] = token
+        return HTTPClient(host, port, scheme, verify=verify, cert=None, headers=headers)
 
 
 def _should_support(c):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -11,7 +11,7 @@ Request = collections.namedtuple(
 
 class HTTPClient(object):
     def __init__(self, host=None, port=None, scheme=None,
-                 verify=True, cert=None):
+                 verify=True, cert=None, headers=None):
         pass
 
     def get(self, callback, path, params=None):


### PR DESCRIPTION
Hi,

according to latest consul documentation for authentication: https://www.consul.io/api/index.html#authentication, consul client should insert token to the header when sending requests to agent.

This is my implementation, hopefully it'll help somebody.

Thank you for your great work.

Dominik