### PR TITLE
after consul 1.0 the deregister of service is a put and not a get

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -886,7 +886,7 @@ class Consul(object):
                 take care of deregistering the service with the Catalog. If
                 there is an associated check, that is also deregistered.
                 """
-                return self.agent.http.get(
+                return self.agent.http.put(
                     CB.bool(), '/v1/agent/service/deregister/%s' % service_id)
 
             def maintenance(self, service_id, enable, reason=None):


### PR DESCRIPTION
Hey,

So after consul 1.0 the de-register of service is a put and not a get. I made the update in the code and submitting it for getting merged

Thanks,

Vignesh