### PR TITLE
RFC: Implement support for connecting to consul via unix socket

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ Example
     import consul
 
     c = consul.Consul()
+    # alternatively create client from envrionment variables
+    # c = consul.Consul.from_env()
 
     # poll a key for updates
     index = None
@@ -28,6 +30,17 @@ Example
 
     # in another process
     c.kv.put('foo', 'bar')
+
+.. code:: python
+
+    import consul
+
+    # Alternatively create a client from the same environment variables that the
+    # consul command line client uses. e.g. CONSUL_HTTP_ADDR, CONSUL_HTTP_TOKEN
+    c = consul.Consul.from_env()
+
+    c.agent.self()
+
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,8 @@ Example
     c.kv.put('foo', 'bar')
 
 
-Alternatively you can create a client from the same environment variables that
-the consul command line client uses. e.g. CONSUL_HTTP_ADDR, CONSUL_HTTP_TOKEN
-See https://www.consul.io/docs/commands/index.html#environment-variables
+Alternatively you can create a client from the same `environment variables`_ that
+the consul command line client uses. e.g. CONSUL_HTTP_ADDR, CONSUL_HTTP_TOKEN.
 
 .. code:: python
 
@@ -59,6 +58,7 @@ Installation
    image:: https://img.shields.io/coveralls/cablehead/python-consul.svg?style=flat-square
    :target: https://coveralls.io/r/cablehead/python-consul?branch=master
 .. _Read the Docs: https://python-consul.readthedocs.io/
+.. _environment variables: https://www.consul.io/docs/commands/index.html#environment-variables
 
 Status
 ------

--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,6 @@ Example
     import consul
 
     c = consul.Consul()
-    # alternatively create client from envrionment variables
-    # c = consul.Consul.from_env()
 
     # poll a key for updates
     index = None
@@ -31,12 +29,15 @@ Example
     # in another process
     c.kv.put('foo', 'bar')
 
+
+Alternatively you can create a client from the same environment variables that
+the consul command line client uses. e.g. CONSUL_HTTP_ADDR, CONSUL_HTTP_TOKEN
+See https://www.consul.io/docs/commands/index.html#environment-variables
+
 .. code:: python
 
     import consul
 
-    # Alternatively create a client from the same environment variables that the
-    # consul command line client uses. e.g. CONSUL_HTTP_ADDR, CONSUL_HTTP_TOKEN
     c = consul.Consul.from_env()
 
     c.agent.self()

--- a/consul/aio.py
+++ b/consul/aio.py
@@ -26,7 +26,7 @@ class HTTPClient(base.HTTPClient):
                                               path=pr.path)
         else:
             connector = aiohttp.TCPConnector(loop=self._loop,
-                                         verify_ssl=self.verify)
+                                             verify_ssl=self.verify)
         self._session = aiohttp.ClientSession(connector=connector)
 
     @asyncio.coroutine

--- a/consul/aio.py
+++ b/consul/aio.py
@@ -3,6 +3,8 @@ import sys
 import asyncio
 import warnings
 
+from six.moves import urllib
+
 import aiohttp
 from consul import base
 
@@ -17,7 +19,13 @@ class HTTPClient(base.HTTPClient):
     def __init__(self, *args, loop=None, **kwargs):
         super(HTTPClient, self).__init__(*args, **kwargs)
         self._loop = loop or asyncio.get_event_loop()
-        connector = aiohttp.TCPConnector(loop=self._loop,
+        if 'unix://' in self.base_uri:
+            pr = urllib.parse.urlparse(self.base_uri)
+            self.base_uri = 'http://consul'
+            connector = aiohttp.UnixConnector(loop=self._loop,
+                                              path=pr.path)
+        else:
+            connector = aiohttp.TCPConnector(loop=self._loop,
                                          verify_ssl=self.verify)
         self._session = aiohttp.ClientSession(connector=connector)
 
@@ -64,9 +72,9 @@ class Consul(base.Consul):
         self._loop = loop or asyncio.get_event_loop()
         super().__init__(*args, **kwargs)
 
-    def connect(self, host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, loop=self._loop,
-                          verify=verify, cert=None)
+    def connect(self, base_uri, verify=True, cert=None, auth=None):
+        return HTTPClient(base_uri, loop=self._loop,
+                          verify=verify, cert=cert, auth=auth)
 
     def close(self):
         """Close all opened http connections"""

--- a/consul/base.py
+++ b/consul/base.py
@@ -352,9 +352,26 @@ class Consul(object):
         kwargs = {
             'consistency': consistency,
             'dc': dc,
-            'addr': oe.get('CONSUL_HTTP_ADDR', None),
             'token': oe.get('CONSUL_HTTP_TOKEN', None),
         }
+
+        addr = oe.get('CONSUL_HTTP_ADDR', None)
+        if addr:
+            if not addr.startswith('http'):
+                # Ensure addr starts with a scheme.
+                ssl = oe.get('CONSUL_HTTP_SSL', False)
+                if ssl == 'false':
+                    ssl = False
+                elif ssl == 'true':
+                    ssl = True
+
+                if ssl:
+                    scheme = 'https'
+                else:
+                    scheme = 'http'
+                addr = '%s://%s' % (scheme, addr)
+            kwargs['addr'] = addr
+
         verify = oe.get('CONSUL_CACERT',
                         oe.get('CONSUL_HTTP_SSL_VERIFY', None))
         if verify:

--- a/consul/base.py
+++ b/consul/base.py
@@ -335,7 +335,6 @@ class Consul(object):
         self.coordinate = Consul.Coordinate(self)
         self.operator = Consul.Operator(self)
 
-
     @classmethod
     def from_env(cls, consistency='default', dc=None):
         """
@@ -347,7 +346,7 @@ class Consul(object):
         Additionally all supported given keyword arguments are passed on the
         client constructor.
 
-        [1] https://www.consul.io/docs/commands/index.html#environment-variables
+        [1] https://www.consul.io/docs/commands/index.html#environment-variables # noqa: E501
         """
         oe = os.environ
         kwargs = {
@@ -356,7 +355,8 @@ class Consul(object):
             'addr': oe.get('CONSUL_HTTP_ADDR', None),
             'token': oe.get('CONSUL_HTTP_TOKEN', None),
         }
-        verify = oe.get('CONSUL_CACERT', oe.get('CONSUL_HTTP_SSL_VERIFY', None))
+        verify = oe.get('CONSUL_CACERT',
+                        oe.get('CONSUL_HTTP_SSL_VERIFY', None))
         if verify:
             if verify == 'false':
                 verify = False
@@ -365,14 +365,14 @@ class Consul(object):
             kwargs['verify'] = verify
 
         if 'CONSUL_CLIENT_CERT' in oe \
-            and 'CONSUL_CLIENT_KEY' in oe:
-            kwargs['cert'] = (oe['CONSUL_CLIENT_CERT'], oe['CONSUL_CLIENT_KEY'])
+                and 'CONSUL_CLIENT_KEY' in oe:
+            kwargs['cert'] = (oe['CONSUL_CLIENT_CERT'],
+                              oe['CONSUL_CLIENT_KEY'])
 
         if 'CONSUL_HTTP_AUTH' in oe:
             kwargs['auth'] = oe['CONSUL_HTTP_AUTH'].split(':')
 
         return cls(**kwargs)
-
 
     class Event(object):
         """

--- a/consul/base.py
+++ b/consul/base.py
@@ -354,7 +354,6 @@ class Consul(object):
             'consistency': consistency,
             'dc': dc,
             'addr': oe.get('CONSUL_HTTP_ADDR', None),
-            'verify': oe.get('CONSUL_CACERT', oe.get('CONSUL_HTTP_SSL_VERIFY', False)),
             'token': oe.get('CONSUL_HTTP_TOKEN', None),
         }
         verify = oe.get('CONSUL_CACERT', oe.get('CONSUL_HTTP_SSL_VERIFY', None))

--- a/consul/base.py
+++ b/consul/base.py
@@ -246,14 +246,11 @@ class CB(object):
 
 
 class HTTPClient(six.with_metaclass(abc.ABCMeta, object)):
-    def __init__(self, host='127.0.0.1', port=8500, scheme='http',
-                 verify=True, cert=None):
-        self.host = host
-        self.port = port
-        self.scheme = scheme
+    def __init__(self, base_uri, verify=True, cert=None, auth=None):
+        self.base_uri = base_uri
         self.verify = verify
-        self.base_uri = '%s://%s:%s' % (self.scheme, self.host, self.port)
         self.cert = cert
+        self.auth = auth
 
     def uri(self, path, params=None):
         uri = self.base_uri + urllib.parse.quote(path, safe='/:')
@@ -288,7 +285,9 @@ class Consul(object):
             consistency='default',
             dc=None,
             verify=True,
-            cert=None):
+            cert=None,
+            auth=None,
+            addr=None):
         """
         *token* is an optional `ACL token`_. If supplied it will be used by
         default for all requests made with this client session. It's still
@@ -305,27 +304,19 @@ class Consul(object):
 
         *verify* is whether to verify the SSL certificate for HTTPS requests
 
-        *cert* client side certificates for HTTPS requests
+        *cert* tuple containing client certificate and key for HTTPS requests
+
+        *addr* url to use instead of host, port and scheme.
+            e.g. unix:///var/run/consul/http.sock, http://localhost:8500/
         """
 
         # TODO: Status
 
-        if os.getenv('CONSUL_HTTP_ADDR'):
-            try:
-                host, port = os.getenv('CONSUL_HTTP_ADDR').split(':')
-            except ValueError:
-                raise ConsulException('CONSUL_HTTP_ADDR (%s) invalid, '
-                                      'does not match <host>:<port>'
-                                      % os.getenv('CONSUL_HTTP_ADDR'))
-        use_ssl = os.getenv('CONSUL_HTTP_SSL')
-        if use_ssl is not None:
-            scheme = 'https' if use_ssl == 'true' else 'http'
-        if os.getenv('CONSUL_HTTP_SSL_VERIFY') is not None:
-            verify = os.getenv('CONSUL_HTTP_SSL_VERIFY') == 'true'
+        if not addr:
+            addr = '{0}://{1}:{2}'.format(scheme, host, port)
 
-        self.http = self.connect(host, port, scheme, verify, cert)
-        self.token = os.getenv('CONSUL_HTTP_TOKEN', token)
-        self.scheme = scheme
+        self.http = self.connect(addr, verify=verify, cert=cert, auth=auth)
+        self.token = token
         self.dc = dc
         assert consistency in ('default', 'consistent', 'stale'), \
             'consistency must be either default, consistent or state'
@@ -343,6 +334,46 @@ class Consul(object):
         self.query = Consul.Query(self)
         self.coordinate = Consul.Coordinate(self)
         self.operator = Consul.Operator(self)
+
+
+    @classmethod
+    def from_env(cls, consistency='default', dc=None):
+        """
+        Return a client configured from environment variables.
+        The environment variables used are the same as those used by the
+        consul command-line client. Refer to the consul documentation [1] for
+        a list of existing environment variables.
+
+        Additionally all supported given keyword arguments are passed on the
+        client constructor.
+
+        [1] https://www.consul.io/docs/commands/index.html#environment-variables
+        """
+        oe = os.environ
+        kwargs = {
+            'consistency': consistency,
+            'dc': dc,
+            'addr': oe.get('CONSUL_HTTP_ADDR', None),
+            'verify': oe.get('CONSUL_CACERT', oe.get('CONSUL_HTTP_SSL_VERIFY', False)),
+            'token': oe.get('CONSUL_HTTP_TOKEN', None),
+        }
+        verify = oe.get('CONSUL_CACERT', oe.get('CONSUL_HTTP_SSL_VERIFY', None))
+        if verify:
+            if verify == 'false':
+                verify = False
+            elif verify == 'true':
+                verify = True
+            kwargs['verify'] = verify
+
+        if 'CONSUL_CLIENT_CERT' in oe \
+            and 'CONSUL_CLIENT_KEY' in oe:
+            kwargs['cert'] = (oe['CONSUL_CLIENT_CERT'], oe['CONSUL_CLIENT_KEY'])
+
+        if 'CONSUL_HTTP_AUTH' in oe:
+            kwargs['auth'] = oe['CONSUL_HTTP_AUTH'].split(':')
+
+        return cls(**kwargs)
+
 
     class Event(object):
         """

--- a/consul/std.py
+++ b/consul/std.py
@@ -19,7 +19,7 @@ class HTTPClient(base.HTTPClient):
                 import requests_unixsocket
                 self.session = requests_unixsocket.Session()
             except ImportError:
-                raise ConsulException('To use a unix socket to connect to Consul you need to install the "requests_unixsocket" package.')
+                raise base.ConsulException('To use a unix socket to connect to Consul you need to install the "requests_unixsocket" package.')
         else:
             self.session = requests.session()
 

--- a/consul/std.py
+++ b/consul/std.py
@@ -19,7 +19,8 @@ class HTTPClient(base.HTTPClient):
                 import requests_unixsocket
                 self.session = requests_unixsocket.Session()
             except ImportError:
-                raise base.ConsulException('To use a unix socket to connect to Consul you need to install the "requests_unixsocket" package.')
+                raise base.ConsulException('To use a unix socket to connect to'
+                    'Consul you need to install the "requests_unixsocket" package.')
         else:
             self.session = requests.session()
 

--- a/consul/std.py
+++ b/consul/std.py
@@ -20,7 +20,8 @@ class HTTPClient(base.HTTPClient):
                 self.session = requests_unixsocket.Session()
             except ImportError:
                 raise base.ConsulException('To use a unix socket to connect to'
-                    'Consul you need to install the "requests_unixsocket" package.')
+                                           ' Consul you need to install the'
+                                           ' "requests_unixsocket" package.')
         else:
             self.session = requests.session()
 

--- a/consul/tornado.py
+++ b/consul/tornado.py
@@ -12,6 +12,7 @@ __all__ = ['Consul']
 class HTTPClient(base.HTTPClient):
     def __init__(self, *args, **kwargs):
         super(HTTPClient, self).__init__(*args, **kwargs)
+        # TODO: support for unix:// uris
         self.client = httpclient.AsyncHTTPClient()
 
     def response(self, response):
@@ -53,5 +54,5 @@ class HTTPClient(base.HTTPClient):
 
 
 class Consul(base.Consul):
-    def connect(self, host, port, scheme, verify=True, cert=None):
-        return HTTPClient(host, port, scheme, verify=verify, cert=cert)
+    def connect(self, base_uri, verify=True, cert=None, auth=None):
+        return HTTPClient(base_uri, verify=verify, cert=cert, auth=auth)

--- a/consul/twisted.py
+++ b/consul/twisted.py
@@ -34,6 +34,7 @@ class InsecureContextFactory(ClientContextFactory):
 class HTTPClient(base.HTTPClient):
     def __init__(self, contextFactory, *args, **kwargs):
         super(HTTPClient, self).__init__(*args, **kwargs)
+        # TODO: support for unix:// uris
         agent_kwargs = dict(
             reactor=reactor, pool=HTTPConnectionPool(reactor))
         if contextFactory is not None:
@@ -125,13 +126,12 @@ class HTTPClient(base.HTTPClient):
 
 class Consul(base.Consul):
     @staticmethod
-    def connect(host,
-                port,
-                scheme,
+    def connect(base_uri,
                 verify=True,
                 cert=None,
+                auth=None,
                 contextFactory=None,
                 **kwargs):
         return HTTPClient(
-            contextFactory, host, port, scheme, verify=verify, cert=cert,
+            contextFactory, base_uri, verify=verify, cert=cert, auth=auth,
             **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.0
+requests-unixsocket>=0.1.5
 six>=1.4

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -24,13 +24,17 @@ def loop(request):
     return loop
 
 
+@pytest.fixture
+def c(consul_port, loop):
+    return consul.aio.Consul(port=consul_port, loop=loop)
+
+
 class TestAsyncioConsul(object):
 
-    def test_kv(self, loop, consul_port):
+    def test_kv(self, loop, c):
 
         @asyncio.coroutine
         def main():
-            c = consul.aio.Consul(port=consul_port, loop=loop)
             print(c)
             index, data = yield from c.kv.get('foo')
 
@@ -44,11 +48,10 @@ class TestAsyncioConsul(object):
 
         loop.run_until_complete(main())
 
-    def test_consul_ctor(self, loop, consul_port):
+    def test_consul_ctor(self, loop, c):
         # same as previous but with global event loop
         @asyncio.coroutine
         def main():
-            c = consul.aio.Consul(port=consul_port)
             assert c._loop is loop
             yield from c.kv.put('foo', struct.pack('i', 1000))
             index, data = yield from c.kv.get('foo')
@@ -58,10 +61,9 @@ class TestAsyncioConsul(object):
         asyncio.set_event_loop(loop)
         loop.run_until_complete(main())
 
-    def test_kv_binary(self, loop, consul_port):
+    def test_kv_binary(self, loop, c):
         @asyncio.coroutine
         def main():
-            c = consul.aio.Consul(port=consul_port, loop=loop)
             yield from c.kv.put('foo', struct.pack('i', 1000))
             index, data = yield from c.kv.get('foo')
             assert struct.unpack('i', data['Value']) == (1000,)
@@ -69,8 +71,7 @@ class TestAsyncioConsul(object):
 
         loop.run_until_complete(main())
 
-    def test_kv_missing(self, loop, consul_port):
-        c = consul.aio.Consul(port=consul_port, loop=loop)
+    def test_kv_missing(self, loop, c):
 
         @asyncio.coroutine
         def main():
@@ -90,10 +91,9 @@ class TestAsyncioConsul(object):
 
         loop.run_until_complete(main())
 
-    def test_kv_put_flags(self, loop, consul_port):
+    def test_kv_put_flags(self, loop, c):
         @asyncio.coroutine
         def main():
-            c = consul.aio.Consul(port=consul_port, loop=loop)
             yield from c.kv.put('foo', 'bar')
             index, data = yield from c.kv.get('foo')
             assert data['Flags'] == 0
@@ -106,10 +106,9 @@ class TestAsyncioConsul(object):
 
         loop.run_until_complete(main())
 
-    def test_kv_delete(self, loop, consul_port):
+    def test_kv_delete(self, loop, c):
         @asyncio.coroutine
         def main():
-            c = consul.aio.Consul(port=consul_port, loop=loop)
             yield from c.kv.put('foo1', '1')
             yield from c.kv.put('foo2', '2')
             yield from c.kv.put('foo3', '3')
@@ -128,8 +127,7 @@ class TestAsyncioConsul(object):
 
         loop.run_until_complete(main())
 
-    def test_kv_subscribe(self, loop, consul_port):
-        c = consul.aio.Consul(port=consul_port, loop=loop)
+    def test_kv_subscribe(self, loop, c):
 
         @asyncio.coroutine
         def get():
@@ -149,10 +147,9 @@ class TestAsyncioConsul(object):
 
         loop.run_until_complete(get())
 
-    def test_transaction(self, loop, consul_port):
+    def test_transaction(self, loop, c):
         @asyncio.coroutine
         def main():
-            c = consul.aio.Consul(port=consul_port, loop=loop)
             value = base64.b64encode(b"1").decode("utf8")
             d = {"KV": {"Verb": "set", "Key": "asdf", "Value": value}}
             r = yield from c.txn.put([d])
@@ -164,10 +161,9 @@ class TestAsyncioConsul(object):
             c.close()
         loop.run_until_complete(main())
 
-    def test_agent_services(self, loop, consul_port):
+    def test_agent_services(self, loop, c):
         @asyncio.coroutine
         def main():
-            c = consul.aio.Consul(port=consul_port, loop=loop)
             services = yield from c.agent.services()
             assert services == {}
             response = yield from c.agent.service.register('foo')
@@ -192,8 +188,7 @@ class TestAsyncioConsul(object):
 
         loop.run_until_complete(main())
 
-    def test_catalog(self, loop, consul_port):
-        c = consul.aio.Consul(port=consul_port, loop=loop)
+    def test_catalog(self, loop, c):
 
         @asyncio.coroutine
         def nodes():
@@ -223,8 +218,7 @@ class TestAsyncioConsul(object):
 
         loop.run_until_complete(nodes())
 
-    def test_session(self, loop, consul_port):
-        c = consul.aio.Consul(port=consul_port, loop=loop)
+    def test_session(self, loop, c):
 
         @asyncio.coroutine
         def monitor():

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -64,14 +64,14 @@ class TestEnvironment(object):
         CONSUL_HTTP_ADDR = '127.0.0.23:4242'
         with self.environ(CONSUL_HTTP_ADDR=CONSUL_HTTP_ADDR):
             c = Consul.from_env()
-            assert c.http.base_uri == 'http://'+ CONSUL_HTTP_ADDR
+            assert c.http.base_uri == 'http://' + CONSUL_HTTP_ADDR
 
     def test_CONSUL_HTTP_ADDR_with_CONSUL_HTTP_SSL(self):
         CONSUL_HTTP_ADDR = '127.0.0.23:4242'
         with self.environ(CONSUL_HTTP_ADDR=CONSUL_HTTP_ADDR,
                           CONSUL_HTTP_SSL='true'):
             c = Consul.from_env()
-            assert c.http.base_uri == 'https://'+ CONSUL_HTTP_ADDR
+            assert c.http.base_uri == 'https://' + CONSUL_HTTP_ADDR
 
     def test_CONSUL_HTTP_TOKEN(self):
         CONSUL_HTTP_TOKEN = '1bdc2cb4-9b02-4b3c-9df5-eb86214e1a6c'

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -37,7 +37,6 @@ class Consul(consul.base.Consul):
         return HTTPClient(base_uri, verify=verify, cert=cert, auth=auth)
 
 
-
 class TestEnvironment(object):
 
     @contextmanager
@@ -49,7 +48,7 @@ class TestEnvironment(object):
         try:
             yield
         finally:
-            for key,value in original_env.items():
+            for key, value in original_env.items():
                 if value is None:
                     del os.environ[key]
                 else:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -60,6 +60,19 @@ class TestEnvironment(object):
             c = Consul.from_env()
             assert c.http.base_uri == CONSUL_HTTP_ADDR
 
+    def test_CONSUL_HTTP_ADDR_scheme_http(self):
+        CONSUL_HTTP_ADDR = '127.0.0.23:4242'
+        with self.environ(CONSUL_HTTP_ADDR=CONSUL_HTTP_ADDR):
+            c = Consul.from_env()
+            assert c.http.base_uri == 'http://'+ CONSUL_HTTP_ADDR
+
+    def test_CONSUL_HTTP_ADDR_with_CONSUL_HTTP_SSL(self):
+        CONSUL_HTTP_ADDR = '127.0.0.23:4242'
+        with self.environ(CONSUL_HTTP_ADDR=CONSUL_HTTP_ADDR,
+                          CONSUL_HTTP_SSL='true'):
+            c = Consul.from_env()
+            assert c.http.base_uri == 'https://'+ CONSUL_HTTP_ADDR
+
     def test_CONSUL_HTTP_TOKEN(self):
         CONSUL_HTTP_TOKEN = '1bdc2cb4-9b02-4b3c-9df5-eb86214e1a6c'
         with self.environ(CONSUL_HTTP_TOKEN=CONSUL_HTTP_TOKEN):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -84,13 +84,13 @@ class TestEnvironment(object):
         CONSUL_HTTP_SSL_VERIFY = 'true'
         with self.environ(CONSUL_HTTP_SSL_VERIFY=CONSUL_HTTP_SSL_VERIFY):
             c = Consul.from_env()
-            assert c.http.verify == True
+            assert c.http.verify is True
 
     def test_CONSUL_HTTP_SSL_VERIFY_False(self):
         CONSUL_HTTP_SSL_VERIFY = 'false'
         with self.environ(CONSUL_HTTP_SSL_VERIFY=CONSUL_HTTP_SSL_VERIFY):
             c = Consul.from_env()
-            assert c.http.verify == False
+            assert c.http.verify is False
 
     def test_CONSUL_CACERT(self):
         CONSUL_CACERT = '/path/to/ca.crt'

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -42,12 +42,14 @@ class TestEnvironment(object):
 
     @contextmanager
     def environ(self, **env):
-        original_env = {key: os.getenv(key) for key in env}
+        original_env = {}
+        for key in env:
+            original_env[key] = os.getenv(key)
         os.environ.update(env)
         try:
             yield
         finally:
-            for key, value in original_env.items():
+            for key,value in original_env.items():
                 if value is None:
                     del os.environ[key]
                 else:

--- a/tests/test_std.py
+++ b/tests/test_std.py
@@ -15,7 +15,7 @@ Check = consul.Check
 
 class TestHTTPClient(object):
     def test_uri(self):
-        http = consul.std.HTTPClient()
+        http = consul.std.HTTPClient('http://127.0.0.1:8500')
         assert http.uri('/v1/kv') == 'http://127.0.0.1:8500/v1/kv'
         assert http.uri('/v1/kv', params={'index': 1}) == \
             'http://127.0.0.1:8500/v1/kv?index=1'

--- a/tests/test_std.py
+++ b/tests/test_std.py
@@ -204,7 +204,6 @@ class TestConsul(object):
             check_id='check_id') is True
         verify_and_dereg_check('check_id')
 
-        #http_addr = "http://127.0.0.1:{0}".format(c)
         http_addr = c.http.base_uri
         assert c.agent.check.register(
             'http_check', Check.http(http_addr, '10ms')) is True


### PR DESCRIPTION
Basically I need python-consul to work with this:

```sh
# env | grep CONSUL_HTTP_ADDR
CONSUL_HTTP_ADDR=unix:///var/run/consul/http.sock
```

Just like the consul cli does.

Unfortunately I had to change a lot of code to make this work :-(
Basically the uri (unix:///var/run/consul/http.sock) has to be passed to all the different implementations like std, aio, tornado as they all handle this type of connection differently.
I implemented the feature for all the backends I'm familiar with std and aio but not tornado and twisted.

I also removed the default environment variables support in base.py for 2 reasons:
- The existing implementation interfered with the feature I wanted to implement.
- I strongly believe a environment variable should never override an explicitly defined argument.

To fully support configuring a client through environment variables I added a explicit helper function similar to how the docker-py project implements it.

```
c = consul.Consul.from_env()
```
