### PR TITLE
Allow adding meta data when registering service

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -819,6 +819,7 @@ class Consul(object):
                     tags=None,
                     check=None,
                     token=None,
+                    meta=None,
                     # *deprecated* use check parameter
                     script=None,
                     interval=None,
@@ -848,6 +849,8 @@ class Consul(object):
                 Note this call will return successful even if the token doesn't
                 have permissions to register this service.
 
+                *meta* is an optional meta data, dictionary formatted as {k1:v1, k2:v2}.
+
                 *script*, *interval*, *ttl*, *http*, and *timeout* arguments
                 are deprecated. use *check* instead.
 
@@ -873,7 +876,8 @@ class Consul(object):
                     payload['port'] = port
                 if tags:
                     payload['tags'] = tags
-
+                if meta:
+                    payload['meta'] = meta
                 if check:
                     payload['check'] = check
 

--- a/consul/base.py
+++ b/consul/base.py
@@ -878,7 +878,7 @@ class Consul(object):
                 if tags:
                     payload['tags'] = tags
                 if meta:
-                    payload['meta'] = meta
+                    payload['meta'] = {str(k): str(v) for (k, v) in meta.items()}
                 if check:
                     payload['check'] = check
 

--- a/consul/base.py
+++ b/consul/base.py
@@ -878,7 +878,7 @@ class Consul(object):
                 if tags:
                     payload['tags'] = tags
                 if meta:
-                    payload['meta'] = {str(k): str(v) for (k, v) in meta.items()}
+                    payload['meta'] = meta
                 if check:
                     payload['check'] = check
 

--- a/consul/base.py
+++ b/consul/base.py
@@ -849,7 +849,8 @@ class Consul(object):
                 Note this call will return successful even if the token doesn't
                 have permissions to register this service.
 
-                *meta* is an optional meta data, dictionary formatted as {k1:v1, k2:v2}.
+                *meta* specifies arbitrary KV metadata linked to the service
+                formatted as {k1:v1, k2:v2}.
 
                 *script*, *interval*, *ttl*, *http*, and *timeout* arguments
                 are deprecated. use *check* instead.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 import collections
+import json
 
 import pytest
 
@@ -62,6 +63,14 @@ def _should_support_node_meta(c):
     )
 
 
+def _should_support_meta(c):
+    return (
+        # agent
+        lambda **kw: c.agent.service.register('foo', **kw),
+        lambda **kw: c.agent.service.register('foo', 'bar', **kw),
+    )
+
+
 class TestIndex(object):
     """
     Tests read requests that should support blocking on an index
@@ -105,6 +114,18 @@ class TestNodemeta(object):
             assert r().params == []
             assert sorted(r(node_meta={'env': 'prod', 'net': 1}).params) == \
                 sorted([('node-meta', 'net:1'), ('node-meta', 'env:prod')])
+
+
+class TestMeta(object):
+    """
+    Tests read requests that should support meta
+    """
+
+    def test_meta(self):
+        c = Consul()
+        for r in _should_support_meta(c):
+            assert sorted(json.loads(r(meta={'env': 'prod', 'net': 1}).data)['meta']) == \
+                sorted({'env': 'prod', 'net': 1})
 
 
 class TestCB(object):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -124,8 +124,8 @@ class TestMeta(object):
     def test_meta(self):
         c = Consul()
         for r in _should_support_meta(c):
-            assert sorted(json.loads(r(meta={'env': 'prod', 'net': 1}).data)['meta']) == \
-                sorted({'env': 'prod', 'net': 1})
+            d = json.loads(r(meta={'env': 'prod', 'net': 1}).data)
+            assert sorted(d['meta']) == sorted({'env': 'prod', 'net': 1})
 
 
 class TestCB(object):


### PR DESCRIPTION
I like to add meta data to my services, this allows just that. It's a variation of #222 