### PR TITLE
fixes #226

### DIFF
--- a/consul/aio.py
+++ b/consul/aio.py
@@ -55,7 +55,7 @@ class HTTPClient(base.HTTPClient):
         return self._request(callback, 'POST', uri, data=data)
 
     def close(self):
-        self._session.close()
+        return self._session.close()
 
 
 class Consul(base.Consul):
@@ -70,4 +70,4 @@ class Consul(base.Consul):
 
     def close(self):
         """Close all opened http connections"""
-        self.http.close()
+        return self.http.close()


### PR DESCRIPTION
For avoid #226 I should call `close()` method on the running loop, but for awaiting the result it's not needed. Just returning a coroutine object from connector.