### PR TITLE
Added node parameter to data in Catalog register

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -1152,6 +1152,7 @@ class Consul(object):
                 data['WriteRequest'] = {'Token': token}
                 params.append(('token', token))
             if node_meta:
+                data['nodemeta'] = node_meta
                 for nodemeta_name, nodemeta_value in node_meta.items():
                     params.append(('node-meta', '{0}:{1}'.
                                    format(nodemeta_name, nodemeta_value)))


### PR DESCRIPTION
This is done so the API properly passes node_meta data to Consul. PR #222 did not fix this issue. Consul appears to want node_meta in the data body not params.

I am not sure about the exact mechanisms behind the consul server. Should we remove the node_meta addition to params and only add it to the data body?