### PR TITLE
Pushing docs towards Python 3

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -510,7 +510,7 @@ class Consul(object):
                     "LockIndex": 200,
                     "Key": "foo",
                     "Flags": 0,
-                    "Value": "bar",
+                    "Value": b"bar",
                     "Session": "adf4238a-882b-9ddc-4a9d-5b6758e4159e"
                 }
 
@@ -680,7 +680,7 @@ class Consul(object):
                     "KV": {
                       "Verb": "<verb>",
                       "Key": "<key>",
-                      "Value": "<Base64-encoded blob of data>",
+                      "Value": b"<Base64-encoded blob of data>",
                       "Flags": 0,
                       "Index": 0,
                       "Session": "<session id>"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ creating server components - but it does serve as a base. It makes use of the
 
     >>> index, data = c.kv.get('foo')
     >>> data['Value']
-    'bar'
+    b'bar'
 
     # this will block until there's an update or a timeout
     >>> index, data = c.kv.get('foo', index=index)


### PR DESCRIPTION
It is not clear from the docs that there is a difference in the returned value between Python 2 and Python 3 (#177 ), so I made a few changes that would make it clear that on Python 3 return value is actually composed of bytes instead of a string.

I did not bother with specifying that Python 2 returns a string mainly because it is being retired by the end of this year. Feel free to push changes that would make clear the distinction between python 2 and 3 return values.