### PR TITLE
Fix: Added token to params for sessions.

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -687,8 +687,16 @@ class Consul(object):
                     }
                 }
             """
-            return self.agent.http.put(CB.json(), "/v1/txn",
-                                       data=json.dumps(payload))
+            params = []
+            token = self.agent.token
+            if token:
+                params.append(('token', tokenn))
+            return self.agent.http.put(
+                    CB.json(), 
+                    "/v1/txn", 
+                    params=params,
+                    data=json.dumps(payload)
+            )
 
     class Agent(object):
         """

--- a/consul/base.py
+++ b/consul/base.py
@@ -1793,6 +1793,9 @@ class Consul(object):
             dc = dc or self.agent.dc
             if dc:
                 params.append(('dc', dc))
+            token = self.agent.token
+            if token:
+                params.append(('token', token))
             return self.agent.http.put(
                 CB.bool(),
                 '/v1/session/destroy/%s' % session_id,
@@ -1841,6 +1844,9 @@ class Consul(object):
             consistency = consistency or self.agent.consistency
             if consistency in ('consistent', 'stale'):
                 params.append((consistency, '1'))
+            token = self.agent.token
+            if token:
+                params.append(('token', token))
             return self.agent.http.get(
                 CB.json(index=True), '/v1/session/list', params=params)
 
@@ -1871,6 +1877,9 @@ class Consul(object):
             consistency = consistency or self.agent.consistency
             if consistency in ('consistent', 'stale'):
                 params.append((consistency, '1'))
+            token = self.agent.token
+            if token:
+                params.append(('token', token))
             return self.agent.http.get(
                 CB.json(index=True),
                 '/v1/session/node/%s' % node, params=params)
@@ -1908,6 +1917,9 @@ class Consul(object):
             consistency = consistency or self.agent.consistency
             if consistency in ('consistent', 'stale'):
                 params.append((consistency, '1'))
+            token = self.agent.token
+            if token:
+                params.append(('token', token))
             return self.agent.http.get(
                 CB.json(index=True, one=True),
                 '/v1/session/info/%s' % session_id,
@@ -1927,6 +1939,9 @@ class Consul(object):
             dc = dc or self.agent.dc
             if dc:
                 params.append(('dc', dc))
+            token = self.agent.token
+            if token:
+                params.append(('token', token))
             return self.agent.http.put(
                 CB.json(one=True, allow_404=False),
                 '/v1/session/renew/%s' % session_id,
@@ -2437,3 +2452,4 @@ class Consul(object):
             """
             return self.agent.http.get(
                 CB.json(), '/v1/operator/raft/configuration')
+

--- a/consul/base.py
+++ b/consul/base.py
@@ -1769,6 +1769,9 @@ class Consul(object):
             if ttl:
                 assert 10 <= ttl <= 86400
                 data['ttl'] = '%ss' % ttl
+            token = self.agent.token
+            if token:
+                params.append(('token', token))
             if data:
                 data = json.dumps(data)
             else:


### PR DESCRIPTION
Tokens in `params` was missing when creating and manipulating `consul.Sessions` objects. Since the `consul.Consul` object already has token in attributes, I'm trying to refer to the agent's token attribute via `self.agent.token`.

cc: @matusvalo @abn   @cablehead can you please review.