### PR TITLE
Add new acl system

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -353,7 +353,6 @@ class Consul(object):
         self.query = Consul.Query(self)
         self.coordinate = Consul.Coordinate(self)
         self.operator = Consul.Operator(self)
-        self.acl_v2 = Consul
 
     class Event(object):
         """
@@ -1969,7 +1968,7 @@ class Consul(object):
             return self.agent.http.delete(
                 CB.json(), '/v1/acl/token/{}'.format(accessor_id))
 
-        def list_tokens(self, token=None):
+        def list_tokens(self):
             return self.agent.http.get(
                 CB.json(), '/v1/acl/tokens')
 
@@ -1989,7 +1988,7 @@ class Consul(object):
             return self.agent.http.delete(
                 CB.json(), '/v1/acl/policy/{}'.format(policy_id))
 
-        def list_policies(self, token=None):
+        def list_policies(self):
             return self.agent.http.get(
                 CB.json(), '/v1/acl/policies')
         
@@ -2016,6 +2015,46 @@ class Consul(object):
         def list_roles(self, policy_id=None):
             return self.agent.http.get(
                 CB.json(), '/v1/acl/roles', params=[("policy_id", policy_id)] if policy_id != "" else [])
+
+        def create_auth_method(self, auth_method_name, auth_method_type, config, description=None):
+            return self.agent.http.put(
+                CB.json(), '/v1/acl/auth-method', params=args_to_payload(locals()))
+
+        def read_auth_method(self, auth_method_name):
+            return self.agent.http.put(
+                CB.json(), '/v1/acl/auth-method/{}'.format(auth_method_name))
+
+        def update_auth_method(self, auth_method_name, auth_method_type, config, description=None):
+            return self.agent.http.put(
+                CB.json(), '/v1/acl/auth-method/{}'.format(auth_method_name), args_to_payload(locals()))
+
+        def delete_auth_method(self, auth_method_name):
+            return self.agent.http.delete(
+                CB.json(), '/v1/acl/auth-method/{}'.format(auth_method_name))
+
+        def list_auth_methods(self):
+            return self.agent.http.get(
+                CB.json(), '/v1/acl/auth-methods')
+
+        def create_binding_rule(self, binding_rule, bind_type, bind_name, description=None, selector=None):
+            return self.agent.http.put(
+                CB.json(), '/v1/acl/binding-rule', params=args_to_payload(locals()))
+
+        def read_binding_rule(self, binding_rule_id):
+            return self.agent.http.put(
+                CB.json(), '/v1/acl/binding-rule/{}'.format(binding_rule_id))
+
+        def update_binding_rule(self, binding_rule_id, auth_method, bind_type, bind_name, description=None, selector=None):
+            return self.agent.http.put(
+                CB.json(), '/v1/acl/binding-rule/{}'.format(binding_rule_id), args_to_payload(locals()))
+
+        def delete_binding_rule(self, binding_rule_id):
+            return self.agent.http.delete(
+                CB.json(), '/v1/acl/binding-rule/{}'.format(binding_rule_id))
+
+        def list_binding_rules(self):
+            return self.agent.http.get(
+                CB.json(), '/v1/acl/binding-rules')
 
         def list(self, token=None):
             """

--- a/consul/base.py
+++ b/consul/base.py
@@ -1957,7 +1957,7 @@ class Consul(object):
 
         def update_token(self, accessor_id, secret_id=None, description=None, policies=None, roles=None, service_identities=None, local=None, expiration_time=None, expiration_ttl=None):
             return self.agent.http.put(
-                CB.json(), '/v1/acl/policies/{}'.format(accessor_id), params=args_to_payload(locals()))
+                CB.json(), '/v1/acl/token/{}'.format(accessor_id), params=args_to_payload(locals()))
 
         def clone_token(self, accessor_id, description=None):
             return self.agent.http.put(

--- a/consul/base.py
+++ b/consul/base.py
@@ -13,6 +13,16 @@ from six.moves import urllib
 log = logging.getLogger(__name__)
 
 
+def args_to_payload(args_map):
+    return [
+        (key, value)
+        for key, value in
+        {
+            k: v for
+            k, v in args_map.items() if v is not None and k != "self"
+        }.items()
+    ]
+
 class ConsulException(Exception):
     pass
 
@@ -343,6 +353,7 @@ class Consul(object):
         self.query = Consul.Query(self)
         self.coordinate = Consul.Coordinate(self)
         self.operator = Consul.Operator(self)
+        self.acl_v2 = Consul
 
     class Event(object):
         """
@@ -1932,6 +1943,79 @@ class Consul(object):
     class ACL(object):
         def __init__(self, agent):
             self.agent = agent
+
+        def create_token(self, accessor_id=None, secret_id=None, description=None, policies=None, roles=None, service_identities=None, local=None, expiration_time=None, expiration_ttl=None):
+            return self.agent.http.put(
+                CB.json(), '/v1/acl/token', params=args_to_payload(locals()))
+
+        def read_token(self, accessor_id):
+            return self.agent.http.get(
+                CB.json(), '/v1/acl/token/{}'.format(accessor_id))
+
+        def read_self_token(self):
+            return self.agent.http.get(
+                CB.json(), '/v1/acl/token/self')
+
+        def update_token(self, accessor_id, secret_id=None, description=None, policies=None, roles=None, service_identities=None, local=None, expiration_time=None, expiration_ttl=None):
+            return self.agent.http.put(
+                CB.json(), '/v1/acl/policies/{}'.format(accessor_id), params=args_to_payload(locals()))
+
+        def clone_token(self, accessor_id, description=None):
+            return self.agent.http.put(
+                CB.json(), '/v1/acl/token/{}/clone'.format(accessor_id),
+                params=[("description", description)] if description != "" else [])
+
+        def delete_token(self, accessor_id):
+            return self.agent.http.delete(
+                CB.json(), '/v1/acl/token/{}'.format(accessor_id))
+
+        def list_tokens(self, token=None):
+            return self.agent.http.get(
+                CB.json(), '/v1/acl/tokens')
+
+        def create_policy(self, name, description=None, rules=None, datacenters=None):
+            return self.agent.http.put(
+                CB.json(), '/v1/acl/policy', params=args_to_payload(locals()))
+
+        def read_policy(self, policy_id):
+            return self.agent.http.get(
+                CB.json(), '/v1/acl/policy/{}'.format(policy_id))
+
+        def update_policy(self, policy_id, name, description=None, rules=None, datacenters=None):
+            return self.agent.http.put(
+                CB.json(), '/v1/acl/policy/{}'.format(policy_id), args_to_payload(locals()))
+
+        def delete_policy(self, policy_id):
+            return self.agent.http.delete(
+                CB.json(), '/v1/acl/policy/{}'.format(policy_id))
+
+        def list_policies(self, token=None):
+            return self.agent.http.get(
+                CB.json(), '/v1/acl/policies')
+        
+        def create_role(self, name, description=None, policies=None, service_identities=None):
+            return self.agent.http.put(
+                CB.json(), '/v1/acl/role', params=args_to_payload(locals()))
+
+        def read_role(self, role_id):
+            return self.agent.http.get(
+                CB.json(), '/v1/acl/role/{}'.format(role_id))
+
+        def read_role_by_name(self, role_name):
+            return self.agent.http.get(
+                CB.json(), '/v1/acl/role/name/{}'.format(role_name))
+
+        def update_role(self, role_id, name, description=None, policies=None, service_identities=None):
+            return self.agent.http.put(
+                CB.json(), '/v1/acl/role/{}'.format(role_id), args_to_payload(locals()))
+
+        def delete_role(self, role_id):
+            return self.agent.http.delete(
+                CB.json(), '/v1/acl/role/{}'.format(role_id))
+
+        def list_roles(self, policy_id=None):
+            return self.agent.http.get(
+                CB.json(), '/v1/acl/roles', params=[("policy_id", policy_id)] if policy_id != "" else [])
 
         def list(self, token=None):
             """


### PR DESCRIPTION
Hi @cablehead,

It concerns new acl system for consul 1.4 and 1.5

In this pr I had the possibility to manage the following parts of the ACL api:
 * https://www.consul.io/api/acl/tokens.html
 * https://www.consul.io/api/acl/policies.html
 * https://www.consul.io/api/acl/roles.html
 * https://www.consul.io/api/acl/auth-methods.html
 * https://www.consul.io/api/acl/binding-rules.html