### PR TITLE
Allow agent commands to supply an ACL token (like register can)

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -901,16 +901,27 @@ class Consul(object):
                     params=params,
                     data=json.dumps(payload))
 
-            def deregister(self, service_id):
+            def deregister(self, service_id, token=None):
                 """
                 Used to remove a service from the local agent. The agent will
                 take care of deregistering the service with the Catalog. If
                 there is an associated check, that is also deregistered.
-                """
-                return self.agent.http.put(
-                    CB.bool(), '/v1/agent/service/deregister/%s' % service_id)
 
-            def maintenance(self, service_id, enable, reason=None):
+                *service_id* is the id of the service that is to be deregistered
+
+                *token* is an optional `ACL token`_ to apply to this request.
+                """
+
+                params = []
+                token = token or self.agent.token
+                if token:
+                    params.append(('token', token))
+                return self.agent.http.put(
+                    CB.bool(),
+                    '/v1/agent/service/deregister/%s' % service_id,
+                    params=params)
+
+            def maintenance(self, service_id, enable, reason=None, token=None):
                 """
                 The service maintenance endpoint allows placing a given service
                 into "maintenance mode".
@@ -923,6 +934,8 @@ class Consul(object):
 
                 *reason* is an optional string. This is simply to aid human
                 operators.
+
+                *token* is an optional `ACL token`_ to apply to this request.
                 """
 
                 params = []
@@ -930,6 +943,10 @@ class Consul(object):
                 params.append(('enable', enable))
                 if reason:
                     params.append(('reason', reason))
+
+                token = token or self.agent.token
+                if token:
+                    params.append(('token', token))
 
                 return self.agent.http.put(
                     CB.bool(),
@@ -1016,15 +1033,23 @@ class Consul(object):
                     params=params,
                     data=json.dumps(payload))
 
-            def deregister(self, check_id):
+            def deregister(self, check_id, token=None):
                 """
                 Remove a check from the local agent.
+
+                *token* is an optional `ACL token`_ to apply to this request.
                 """
+
+                params = []
+                token = token or self.agent.token
+                if token:
+                    params.append(('token', token))
                 return self.agent.http.put(
                     CB.bool(),
-                    '/v1/agent/check/deregister/%s' % check_id)
+                    '/v1/agent/check/deregister/%s' % check_id,
+                    params=params)
 
-            def ttl_pass(self, check_id, notes=None):
+            def ttl_pass(self, check_id, notes=None, token=None):
                 """
                 Mark a ttl based check as passing. Optional notes can be
                 attached to describe the status of the check.
@@ -1033,12 +1058,16 @@ class Consul(object):
                 if notes:
                     params.append(('note', notes))
 
+                token = token or self.agent.token
+                if token:
+                    params.append(('token', token))
+
                 return self.agent.http.put(
                     CB.bool(),
                     '/v1/agent/check/pass/%s' % check_id,
                     params=params)
 
-            def ttl_fail(self, check_id, notes=None):
+            def ttl_fail(self, check_id, notes=None, token=None):
                 """
                 Mark a ttl based check as failing. Optional notes can be
                 attached to describe why check is failing. The status of the
@@ -1048,12 +1077,16 @@ class Consul(object):
                 if notes:
                     params.append(('note', notes))
 
+                token = token or self.agent.token
+                if token:
+                    params.append(('token', token))
+
                 return self.agent.http.put(
                     CB.bool(),
                     '/v1/agent/check/fail/%s' % check_id,
                     params=params)
 
-            def ttl_warn(self, check_id, notes=None):
+            def ttl_warn(self, check_id, notes=None, token=None):
                 """
                 Mark a ttl based check with warning. Optional notes can be
                 attached to describe the warning. The status of the
@@ -1062,6 +1095,10 @@ class Consul(object):
                 params = []
                 if notes:
                     params.append(('note', notes))
+
+                token = token or self.agent.token
+                if token:
+                    params.append(('token', token))
 
                 return self.agent.http.put(
                     CB.bool(),

--- a/consul/base.py
+++ b/consul/base.py
@@ -907,7 +907,7 @@ class Consul(object):
                 take care of deregistering the service with the Catalog. If
                 there is an associated check, that is also deregistered.
 
-                *service_id* is the id of the service that is to be deregistered
+                *service_id* is the id of the service to be deregistered
 
                 *token* is an optional `ACL token`_ to apply to this request.
                 """


### PR DESCRIPTION
This is to address : https://github.com/cablehead/python-consul/issues/255