### PR TITLE
Port away from requests -> urllib3 for thread-safety. Resolves #144.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - pypy-5.3.1
   - 3.5
   - 3.6
+  - 3.7
 
 install:
   - pip install tox

--- a/consul/std.py
+++ b/consul/std.py
@@ -12,7 +12,8 @@ class HTTPClient(base.HTTPClient):
         super(HTTPClient, self).__init__(*args, **kwargs)
         cert_file = kwargs.get('cert', None)
         cert_reqs = 'CERT_REQUIRED' if kwargs.get('verify', False) else None
-        self.session = urllib3.PoolManager(cert_file=cert_file, cert_reqs=cert_reqs)
+        self.session = urllib3.PoolManager(cert_file=cert_file,
+                                           cert_reqs=cert_reqs)
 
     def response(self, response):
         return base.Response(

--- a/consul/std.py
+++ b/consul/std.py
@@ -1,42 +1,42 @@
-import requests
+import urllib3
 
 from consul import base
 
 
 __all__ = ['Consul']
+JSON_HEADER = {'Content-Type': 'application/json'}
 
 
 class HTTPClient(base.HTTPClient):
     def __init__(self, *args, **kwargs):
         super(HTTPClient, self).__init__(*args, **kwargs)
-        self.session = requests.session()
+        cert_file = kwargs.get('cert', None)
+        cert_reqs = 'CERT_REQUIRED' if kwargs.get('verify', False) else None
+        self.session = urllib3.PoolManager(cert_file=cert_file, cert_reqs=cert_reqs)
 
     def response(self, response):
-        response.encoding = 'utf-8'
         return base.Response(
-            response.status_code, response.headers, response.text)
+            response.status, response.headers, response.data.decode('utf-8'))
 
     def get(self, callback, path, params=None):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.get(uri, verify=self.verify, cert=self.cert)))
+            self.session.request('GET', uri)))
 
     def put(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.put(uri, data=data, verify=self.verify,
-                             cert=self.cert)))
+            self.session.request('PUT', uri, body=data, headers=JSON_HEADER)))
 
     def delete(self, callback, path, params=None):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.delete(uri, verify=self.verify, cert=self.cert)))
+            self.session.request('DELETE', uri)))
 
     def post(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
         return callback(self.response(
-            self.session.post(uri, data=data, verify=self.verify,
-                              cert=self.cert)))
+            self.session.request('POST', uri, body=data, headers=JSON_HEADER)))
 
 
 class Consul(base.Consul):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests>=2.0
+urllib3>=1.25
 six>=1.4

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     url='https://github.com/cablehead/python-consul',
     license='MIT',
     description=description,
-    long_description=open('README.rst').read() + '\n\n' +
+    long_description=open('README.rst').read() + '\n\n' +  # noqa: W504
         open('CHANGELOG.rst').read(),
     py_modules=py_modules,
     install_requires=requirements,

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -10,6 +10,10 @@ import consul.aio
 
 
 Check = consul.Check
+if hasattr(asyncio, 'ensure_future'):
+    ensure_future = asyncio.ensure_future
+else:  # Deprecated since Python 3.4.4
+    ensure_future = getattr(asyncio, "async")
 
 
 @pytest.fixture
@@ -74,7 +78,7 @@ class TestAsyncioConsul(object):
 
         @asyncio.coroutine
         def main():
-            fut = asyncio.async(put(), loop=loop)
+            fut = ensure_future(put(), loop=loop)
             yield from c.kv.put('index', 'bump')
             index, data = yield from c.kv.get('foo')
             assert data is None
@@ -133,7 +137,7 @@ class TestAsyncioConsul(object):
 
         @asyncio.coroutine
         def get():
-            fut = asyncio.async(put(), loop=loop)
+            fut = ensure_future(put(), loop=loop)
             index, data = yield from c.kv.get('foo')
             assert data is None
             index, data = yield from c.kv.get('foo', index=index)
@@ -197,7 +201,7 @@ class TestAsyncioConsul(object):
 
         @asyncio.coroutine
         def nodes():
-            fut = asyncio.async(register(), loop=loop)
+            fut = ensure_future(register(), loop=loop)
             index, nodes = yield from c.catalog.nodes()
             assert len(nodes) == 1
             current = nodes[0]
@@ -228,7 +232,7 @@ class TestAsyncioConsul(object):
 
         @asyncio.coroutine
         def monitor():
-            fut = asyncio.async(register(), loop=loop)
+            fut = ensure_future(register(), loop=loop)
             index, services = yield from c.session.list()
             assert services == []
             yield from asyncio.sleep(20/1000.0, loop=loop)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py26, py27, pypy, py35, py36
+envlist = flake8, py26, py27, pypy, py35, py36, py37
 
 [flake8]
 ignore = F811,E226
@@ -42,6 +42,22 @@ commands =
     flake8 --exclude=".tox/*,xx/*,__*,docs/*"
 
 [testenv:py36]
+deps =
+    pytest
+    pytest-rerunfailures
+    pytest-twisted
+    twisted
+    treq
+    pyOpenSSL
+    tornado
+    aiohttp
+    flake8
+    requests
+commands =
+    py.test --reruns=3 {posargs:consul tests}
+    flake8 --exclude=".tox/*,xx/*,__*,docs/*"
+
+[testenv:py37]
 deps =
     pytest
     pytest-rerunfailures

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ commands =
 deps =
     pytest
     pytest-rerunfailures
+    requests
 commands =
     py.test --reruns=3 {posargs:consul tests} 
 
@@ -35,6 +36,7 @@ deps =
     tornado
     aiohttp
     flake8
+    requests
 commands =
     py.test --reruns=3 {posargs:consul tests}
     flake8 --exclude=".tox/*,xx/*,__*,docs/*"
@@ -50,6 +52,7 @@ deps =
     tornado
     aiohttp
     flake8
+    requests
 commands =
     py.test --reruns=3 {posargs:consul tests}
     flake8 --exclude=".tox/*,xx/*,__*,docs/*"


### PR DESCRIPTION
This is not yet ready to merge as I running some integration level tests with our software. The problems I reported in #144 were hard to reproduce, so I need to do a few runs before there is a reasonable chance that I can conclude all is well.

In the meantime, I would appreciate feedback.

It is worth noticing that the fix involves porting to `urllib3>=1.25`; that is because it is this version which introduces certificate checking as an option.

I also note in passing that there is a Python3.7 compatibility issue which make it hard for me to get a clean run:

```
/usr/lib/python3.7/ast.py:35: in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
E     File "/main/srhaque/kdedev/python-consul/tests/test_aio.py", line 77
E       fut = asyncio.async(put(), loop=loop)
E                         ^
E   SyntaxError: invalid syntax
```
so I have ignored that for now (these also show up as reserved word warning in 3.6).