### PR TITLE
python_consul: Added support for ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - 2.6
   - 2.7
   - pypy-5.3.1
   - 3.5

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,8 @@ setup(
     url='https://github.com/cablehead/python-consul',
     license='MIT',
     description=description,
-    long_description=open('README.rst').read() + '\n\n' +
-        open('CHANGELOG.rst').read(),
+    long_description=open('README.rst')
+            .read() + '\n\n' + open('CHANGELOG.rst').read(),
     py_modules=py_modules,
     install_requires=requirements,
     extras_require={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,8 @@ def start_consul_instance(acl_master_token=None):
     (system, node, release, version, machine, processor) = platform.uname()
     if system == 'Darwin':
         postfix = 'osx'
+    elif machine == 'aarch64':
+        postfix = 'aarch64'
     else:
         postfix = 'linux64'
     bin = os.path.join(os.path.dirname(__file__), 'consul.'+postfix)

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -74,7 +74,8 @@ class TestAsyncioConsul(object):
 
         @asyncio.coroutine
         def main():
-            fut = asyncio.async(put(), loop=loop)
+            x = getattr(asyncio, 'async')
+            fut = x(put(), loop=loop)
             yield from c.kv.put('index', 'bump')
             index, data = yield from c.kv.get('foo')
             assert data is None
@@ -133,7 +134,8 @@ class TestAsyncioConsul(object):
 
         @asyncio.coroutine
         def get():
-            fut = asyncio.async(put(), loop=loop)
+            x = getattr(asyncio, 'async')
+            fut = x(put(), loop=loop)
             index, data = yield from c.kv.get('foo')
             assert data is None
             index, data = yield from c.kv.get('foo', index=index)
@@ -197,7 +199,8 @@ class TestAsyncioConsul(object):
 
         @asyncio.coroutine
         def nodes():
-            fut = asyncio.async(register(), loop=loop)
+            x = getattr(asyncio, 'async')
+            fut = x(register(), loop=loop)
             index, nodes = yield from c.catalog.nodes()
             assert len(nodes) == 1
             current = nodes[0]
@@ -228,7 +231,8 @@ class TestAsyncioConsul(object):
 
         @asyncio.coroutine
         def monitor():
-            fut = asyncio.async(register(), loop=loop)
+            x = getattr(asyncio, 'async')
+            fut = x(register(), loop=loop)
             index, services = yield from c.session.list()
             assert services == []
             yield from asyncio.sleep(20/1000.0, loop=loop)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py26, py27, pypy, py35, py36
+envlist = flake8, py27, pypy, py35, py36
 
 [flake8]
 ignore = F811,E226
@@ -16,13 +16,6 @@ deps =
     pyOpenSSL
 commands =
     py.test --reruns=3 {posargs:consul tests}
-
-[testenv:py26]
-deps =
-    pytest
-    pytest-rerunfailures
-commands =
-    py.test --reruns=3 {posargs:consul tests} 
 
 [testenv:py35]
 deps =


### PR DESCRIPTION
Added AARCH64 compatible library of consul and made the necessary changes in build script.
Corrected the warning related to python "async" keyword, Remove support for python2.6 because python-consul doesn't support it.