### PR TITLE
aio: add await for session closing

### DIFF
--- a/consul/aio.py
+++ b/consul/aio.py
@@ -36,7 +36,7 @@ class HTTPClient(base.HTTPClient):
             if not self._session.closed:
                 warnings.warn("Unclosed connector in aio.Consul.HTTPClient",
                               ResourceWarning)
-                self.close()
+                self._loop.run_until_complete(self.close())
 
     def get(self, callback, path, params=None):
         uri = self.uri(path, params)
@@ -53,9 +53,9 @@ class HTTPClient(base.HTTPClient):
     def post(self, callback, path, params=None, data=''):
         uri = self.uri(path, params)
         return self._request(callback, 'POST', uri, data=data)
-
+    
     def close(self):
-        self._session.close()
+        return self._session.close()
 
 
 class Consul(base.Consul):
@@ -68,6 +68,7 @@ class Consul(base.Consul):
         return HTTPClient(host, port, scheme, loop=self._loop,
                           verify=verify, cert=None)
 
+    @asyncio.coroutine
     def close(self):
         """Close all opened http connections"""
-        self.http.close()
+        yield from self.http.close()


### PR DESCRIPTION
aio.Consul.close() uses aiohttp.ClientSession.close() which returns a coroutine that was never awaited. When this happens, RuntimeWarnings are raised on termination:

    RuntimeWarning: coroutine 'ClientSession.close' was never awaited
      self._session.close()
    RuntimeWarning: Enable tracemalloc to get the object allocation traceback
    Unclosed client session
    client_session: <aiohttp.client.ClientSession object at 0x7fee7d894340>
    Unclosed connector
    connections: [<a long list of connections>]
    connector: <aiohttp.connector.TCPConnector object at 0x7fee7d894310>
    
I've added await for the close coroutine and by that avoids these warnings.